### PR TITLE
Data format improvements

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
@@ -25,17 +25,22 @@ if ($Format -eq 'text')
     $OutputObjects `
         | Select-Object Entry, RecordName, RecordType, Data `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+        | Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
-        | convertto-csv -NoTypeInformation
+        | convertto-csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
-        | convertto-json
+        | convertto-json `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
@@ -25,21 +25,17 @@ if ($Format -eq 'text')
     $OutputObjects `
         | Select-Object Entry, RecordName, RecordType, Data `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096 `
-        | write-host
+        | Out-String -Width 4096
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
-        | convertto-csv `
-        | Out-String `
-        | write-host
+        | convertto-csv -NoTypeInformation
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
-        | convertto-json `
-        | write-host
+        | convertto-json
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
@@ -42,23 +42,30 @@ if ($Format -eq 'text')
     $OutputObjects `
         | Select-Object Entry, Name, @{N='RecordType';E={Get-DNSRecordType $_.Type}}, Data `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+        | Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
-        | convertto-csv -NoTypeInformation
+        | convertto-csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
-        | convertto-json
+        | convertto-json `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($format -eq 'list')
 {
     $OutputObjects `
         | Select-Object Entry, Name, @{N='RecordType';E={Get-DNSRecordType $_.Type}}, Data `
-        | Format-List
+        | Format-List `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-DnsClientCache.ps1
@@ -9,7 +9,7 @@
     Copyright 2016 Squared Up Limited, All Rights Reserved.
 #>
 Param(
-    [ValidateSet("text","csv","json")]
+    [ValidateSet("text","csv","json", "list")]
     [string] $Format = "csv"
 )
 
@@ -17,13 +17,30 @@ Param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "stop"
 
+function Get-DNSRecordType
+{
+    Param([uint16]$type)
+    switch ($type)
+    {
+        1 { return "A" }
+        2 { return "NS" }
+        5 { return "CNAME" }
+        6 { return "SOA" }
+        12 { return "PTR" }
+        15 { return "MX" }
+        28 { return "AAAA" }
+        33 { return "SRV" }
+        default { return "$type" }
+    }
+}
+
 #Execute the underlying PS
 $OutputObjects = @(Get-DnsClientCache)
 
 if ($Format -eq 'text')
 {
     $OutputObjects `
-        | Select-Object Entry, RecordName, RecordType, Data `
+        | Select-Object Entry, Name, @{N='RecordType';E={Get-DNSRecordType $_.Type}}, Data `
         | Format-Table -AutoSize `
         | Out-String -Width 4096
 }
@@ -36,6 +53,12 @@ elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | convertto-json
+}
+elseif ($format -eq 'list')
+{
+    $OutputObjects `
+        | Select-Object Entry, Name, @{N='RecordType';E={Get-DNSRecordType $_.Type}}, Data `
+        | Format-List
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -55,19 +55,24 @@ if ($Format -eq 'text')
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Csv -NoTypeInformation
+        | ConvertTo-Csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Json
+        | ConvertTo-Json `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -55,23 +55,19 @@ if ($Format -eq 'text')
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096 `
-        | Write-Host
+        | Out-String -Width 4096
 }
 elseif ($Format -eq 'csv')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Csv `
-        | Out-String `
-        | write-host
+        | ConvertTo-Csv -NoTypeInformation
 }
 elseif ($Format -eq 'json')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Json `
-        | write-host
+        | ConvertTo-Json
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -24,7 +24,7 @@ Param(
 	[string] $Before,
     [nullable[int]] $Top,
     [string] $EntryType,
-    [ValidateSet("text","csv","json")]
+    [ValidateSet("text","csv","json", "list")]
     [string] $Format = "csv"
 )
 
@@ -68,6 +68,12 @@ elseif ($Format -eq 'json')
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
         | ConvertTo-Json
+}
+elseif ($format -eq 'list')
+{
+    $EventLogs `
+        | Sort-Object -Property TimeGenerated -Descending `
+        | Format-List
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -55,25 +55,32 @@ if ($Format -eq 'text')
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Csv -NoTypeInformation
+        | ConvertTo-Csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
-        | ConvertTo-Json
+        | ConvertTo-Json `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 elseif ($format -eq 'list')
 {
     $EventLogs `
-        | Sort-Object -Property TimeGenerated -Descending `
-        | Format-List
+		| Sort-Object -Property TimeGenerated -Descending `
+		| Format-List `
+		| Out-String -Width 4096 `
+		| Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -167,20 +167,19 @@ if ($Format -eq 'text')
 {
 	ConvertFrom-Csv ($output -replace '%EOL%','') `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096 `
-        | Write-Host
+        | Out-String -Width 4096
 }
 elseif ($Format -eq 'csv')
 {
-	($output -replace '%EOL%','') | Out-String -Width 4096 | Write-Host
+	($output -replace '%EOL%','') | Out-String -Width 4096
 }
 elseif ($Format -eq 'csvEx')
 {
-	$output | Write-Host
+	$output
 }
 elseif ($Format -eq 'json')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') | ConvertTo-Json | Write-Host
+	ConvertFrom-Csv ($output -replace '%EOL%','') | ConvertTo-Json
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -163,23 +163,32 @@ foreach ($line in $results) {
 }
 
 # Produce output in requested format
+
 if ($Format -eq 'text')
 {
 	ConvertFrom-Csv ($output -replace '%EOL%','') `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
-	($output -replace '%EOL%','') | Out-String -Width 4096
+	$output -replace '%EOL%','' `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csvEx')
 {
-	$output
+	$output `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') | ConvertTo-Json
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+		| ConvertTo-Json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -21,7 +21,7 @@
 	Copyright 2016 Squared Up Limited, All Rights Reserved.
 #>
 Param(
-    [ValidateSet("text","csv","csvEx","json")]
+    [ValidateSet("text","csv","csvEx","json","list")]
     [string] $Format = "csv"
 )
 
@@ -180,6 +180,11 @@ elseif ($Format -eq 'csvEx')
 elseif ($Format -eq 'json')
 {
 	ConvertFrom-Csv ($output -replace '%EOL%','') | ConvertTo-Json
+}
+elseif ($Format -eq 'list')
+{
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+        | Format-List
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -163,28 +163,39 @@ foreach ($line in $results) {
 }
 
 # Produce output in requested format
+
 if ($Format -eq 'text')
 {
 	ConvertFrom-Csv ($output -replace '%EOL%','') `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
-	($output -replace '%EOL%','') | Out-String -Width 4096
+	$output -replace '%EOL%','' `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csvEx')
 {
-	$output
+	$output `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') | ConvertTo-Json
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+		| ConvertTo-Json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'list')
 {
 	ConvertFrom-Csv ($output -replace '%EOL%','') `
-        | Format-List
+        | Format-List `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -18,7 +18,7 @@ Param(
     [string] $OrderBy = "Pid",
     $Descending = $false,
     [int] $Top = "99999",
-    [ValidateSet("text","csv","json")]
+    [ValidateSet("text","csv","json","list")]
     [string] $Format = "csv"
 )
 
@@ -87,6 +87,13 @@ elseif ($Format -eq 'json')
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top `
         | convertto-json
+}
+elseif ($Format -eq 'list')
+{
+    $OutputObjects `
+        | Sort-Object -Property $OrderBy -Descending:$Desc `
+        | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
+        | Format-List
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -72,25 +72,21 @@ if ($Format -eq 'text')
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096 `
-        | write-host
+        | Out-String -Width 4096
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top  `
-        | convertto-csv `
-        | Out-String `
-        | write-host
+        | convertto-csv -NoTypeInformation
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top `
-        | convertto-json `
-        | write-host
+        | convertto-json
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -72,21 +72,26 @@ if ($Format -eq 'text')
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top  `
-        | convertto-csv -NoTypeInformation
+        | convertto-csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top `
-        | convertto-json
+        | convertto-json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -72,28 +72,35 @@ if ($Format -eq 'text')
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top  `
-        | convertto-csv -NoTypeInformation
+        | convertto-csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top `
-        | convertto-json
+        | convertto-json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'list')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
         | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
-        | Format-List
+        | Format-List `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -9,7 +9,7 @@
     Copyright 2016 Squared Up Limited, All Rights Reserved.
 #>
 Param(
-    [ValidateSet("text","csv","json")]
+    [ValidateSet("text","csv","json","list")]
     [string] $Format = "csv"
 )
 
@@ -37,5 +37,11 @@ elseif ($Format -eq 'json')
         | Sort-Object -Property Name `
         | ConvertTo-Json
 }
-
+elseif ($Format -eq 'list')
+{
+    Get-Service `
+        | Sort-Object -Property Name `
+        | Select-Object DisplayName, Status, Name  `
+        | Format-List
+}
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -23,25 +23,32 @@ if ($Format -eq 'text')
         | Sort-Object -Property Name `
         | Select-Object DisplayName, Status, Name  `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Csv -NoTypeInformation
+        | ConvertTo-Csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Json
+        | ConvertTo-Json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'list')
 {
     Get-Service `
         | Sort-Object -Property Name `
         | Select-Object DisplayName, Status, Name  `
-        | Format-List
+        | Format-List `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -23,23 +23,19 @@ if ($Format -eq 'text')
         | Sort-Object -Property Name `
         | Select-Object DisplayName, Status, Name  `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096 `
-        | Write-Host
+        | Out-String -Width 4096
 }
 elseif ($Format -eq 'csv')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Csv `
-        | Out-String `
-        | write-host
+        | ConvertTo-Csv -NoTypeInformation
 }
 elseif ($Format -eq 'json')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Json `
-        | write-host
+        | ConvertTo-Json
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -23,19 +23,24 @@ if ($Format -eq 'text')
         | Sort-Object -Property Name `
         | Select-Object DisplayName, Status, Name  `
         | Format-Table -AutoSize `
-        | Out-String -Width 4096
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Csv -NoTypeInformation
+        | ConvertTo-Csv -NoTypeInformation `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 elseif ($Format -eq 'json')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | ConvertTo-Json
+        | ConvertTo-Json `
+		| Out-String -Width 4096 `
+        | Write-Host
 }
 
 # Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
@@ -5,7 +5,7 @@
         <Category>Operations</Category>
         <WriteAction ID="WA" TypeID="Community.DataOnDemand.WriteAction.GetDnsClientCache">
           <TimeoutSeconds>60</TimeoutSeconds>
-          <Format>text</Format>
+          <Format>csv</Format>
         </WriteAction>
       </Task>
     </Tasks>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
@@ -9,7 +9,7 @@
           <Before></Before>
           <Top>4</Top>
           <EntryType></EntryType>
-          <Format>text</Format>
+          <Format>csv</Format>
           <TimeoutSeconds>120</TimeoutSeconds>
         </WriteAction>
       </Task>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
@@ -4,7 +4,7 @@
       <Task ID="Community.DataOnDemand.GetNetstatCsv" Accessibility="Public" Timeout="60" Enabled="true" Remotable="false" Target="Windows!Microsoft.Windows.Computer">
         <Category>Operations</Category>
         <WriteAction ID="WA" TypeID="Community.DataOnDemand.WriteAction.GetNetstatCsv">
-          <Format>csvEx</Format>
+          <Format>csv</Format>
           <TimeoutSeconds>60</TimeoutSeconds>
         </WriteAction>
       </Task>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
@@ -7,7 +7,7 @@
           <OrderBy>CpuPercent</OrderBy>
           <Descending>true</Descending>
           <Top>10</Top>
-          <Format>text</Format>
+          <Format>csv</Format>
           <TimeoutSeconds>60</TimeoutSeconds>
         </WriteAction>
       </Task>


### PR DESCRIPTION
This PR improves the downstream experience of these tasks when consumed by other tools or viewed in the SCOM console.

## Changes

- CSV format is now valid without requiring the first line to be trimmed from some tasks
- A list format is now provided via the *Format* parameter
- The default returned format is now CSV, as this format is most widely understood by reporting or analytics tools
- DNS Client Cache output is now correct when requesting text/list format
- Whitespace has been normalized to spaces

## Issues Addressed
- #3 
- #4

## Breaking changes
No loss of functionality, although the default output format change may catch some users out (in the case of the Netstat task, this will be for the better as we no longer display the csvEX format by default).  This can always be overridden however, or the current tasks disabled and the probe/write actions used in a custom management pack.
