### PR TITLE
Support Netstat Task on Unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 # Management Pack Projects
 /ManagementPacks/*/MPResources.resources
 
+# MP References
+/References
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
@@ -256,4 +259,3 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
-

--- a/DataOnDemand.sln
+++ b/DataOnDemand.sln
@@ -1,14 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D4B43EB3-688B-4EEE-86BD-088F0B28ABB3}") = "Community.DataOnDemand", "ManagementPacks\Community.DataOnDemand\Community.DataOnDemand.mpproj", "{26ABAEC1-E5BF-4917-8F6B-831231F393B0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{01C800A1-C2EA-4B4C-86EF-224FAB1D6984}"
 	ProjectSection(SolutionItems) = preProject
+		References\Microsoft.Unix.Library.mp = References\Microsoft.Unix.Library.mp
 		readme.md = readme.md
 	EndProjectSection
+EndProject
+Project("{D4B43EB3-688B-4EEE-86BD-088F0B28ABB3}") = "Community.DataOnDemand.Unix", "ManagementPacks\Community.DataOnDemand.Unix\Community.DataOnDemand.Unix.mpproj", "{5AB64C9B-DC39-4C6B-A663-7BAD80097C4D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +23,10 @@ Global
 		{26ABAEC1-E5BF-4917-8F6B-831231F393B0}.Debug|x86.Build.0 = Debug|x86
 		{26ABAEC1-E5BF-4917-8F6B-831231F393B0}.Release|x86.ActiveCfg = Release|x86
 		{26ABAEC1-E5BF-4917-8F6B-831231F393B0}.Release|x86.Build.0 = Release|x86
+		{5AB64C9B-DC39-4C6B-A663-7BAD80097C4D}.Debug|x86.ActiveCfg = Debug|x86
+		{5AB64C9B-DC39-4C6B-A663-7BAD80097C4D}.Debug|x86.Build.0 = Debug|x86
+		{5AB64C9B-DC39-4C6B-A663-7BAD80097C4D}.Release|x86.ActiveCfg = Release|x86
+		{5AB64C9B-DC39-4C6B-A663-7BAD80097C4D}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ManagementPacks/Community.DataOnDemand.Unix/Community.DataOnDemand.Unix.mpproj
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Community.DataOnDemand.Unix.mpproj
@@ -2,12 +2,12 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <ProjectGuid>{26abaec1-e5bf-4917-8f6b-831231f393b0}</ProjectGuid>
-    <RootNamespace>Community.DataOnDemand</RootNamespace>
-    <Name>Community.DataOnDemand</Name>
-    <ManagementPackName>Community.DataOnDemand</ManagementPackName>
-    <Version>1.2.1.0</Version>
-    <MpFrameworkVersion>v7.0.2</MpFrameworkVersion>
+    <ProjectGuid>{5ab64c9b-dc39-4c6b-a663-7bad80097c4d}</ProjectGuid>
+    <RootNamespace>Community.DataOnDemand.Unix</RootNamespace>
+    <Name>Community.DataOnDemand.Unix</Name>
+    <ManagementPackName>Community.DataOnDemand.Unix</ManagementPackName>
+    <Version>1.0.0.0</Version>
+    <MpFrameworkVersion>v7.0</MpFrameworkVersion>
     <MpFrameworkProfile>OM</MpFrameworkProfile>
     <ProductVersion>1.1.0.0</ProductVersion>
   </PropertyGroup>
@@ -35,13 +35,25 @@
       <Alias>SC</Alias>
       <PackageToBundle>False</PackageToBundle>
     </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.SystemCenter.WSManagement.Library">
+      <!-- <HintPath>C:\Program Files (x86)\System Center Visual Studio Authoring Extensions\References\OM2012\Microsoft.SystemCenter.WSManagement.Library.mp</HintPath>-->
+      <Alias>MSWL</Alias>
+      <MinVersion>7.0.8517.0</MinVersion>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
+    <ManagementPackReference Include="Microsoft.Unix.Library">
+      <HintPath>..\..\References\Microsoft.Unix.Library.mp</HintPath>
+      <Alias>MUL</Alias>
+      <MinVersion>7.3.2119.0</MinVersion>
+      <PackageToBundle>False</PackageToBundle>
+    </ManagementPackReference>
     <ManagementPackReference Include="Microsoft.Windows.Library">
       <Alias>Windows</Alias>
       <PackageToBundle>false</PackageToBundle>
     </ManagementPackReference>
     <ManagementPackReference Include="System.Health.Library">
       <Alias>Health</Alias>
-      <PackageToBundle>False</PackageToBundle>
+      <PackageToBundle>false</PackageToBundle>
     </ManagementPackReference>
     <ManagementPackReference Include="System.Library">
       <Alias>System</Alias>
@@ -49,55 +61,29 @@
     </ManagementPackReference>
     <ManagementPackReference Include="Microsoft.SystemCenter.Visualization.Library">
       <Alias>Visualization</Alias>
-      <PackageToBundle>false</PackageToBundle>
+      <PackageToBundle>False</PackageToBundle>
     </ManagementPackReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Modules" />
+    <Folder Include="Tasks" />
+    <Folder Include="Scripts" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ManagementPack.mpx">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Modules\GetDnsClientCacheWA.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Modules\GetEventLogsWA.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Modules\GetNetstatCsvWA.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Modules\GetProcessesWA.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Modules\GetServicesWA.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Tasks\GetDnsClientCache.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Tasks\GetEventLogs.mpx">
+    <Compile Include="Modules\Probe.GetNetstatCsv.mpx">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Tasks\GetNetstatCsv.mpx">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Tasks\GetProcesses.mpx">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Tasks\GetServices.mpx">
-      <SubType>Code</SubType>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Modules" />
-    <Folder Include="Scripts" />
-    <Folder Include="Tasks" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Scripts\Get-DnsClientCache.ps1" />
-    <EmbeddedResource Include="Scripts\Get-EventLogs.ps1" />
-    <EmbeddedResource Include="Scripts\Get-Netstat.ps1" />
-    <EmbeddedResource Include="Scripts\Get-Processes.ps1" />
-    <EmbeddedResource Include="Scripts\Get-Services.ps1" />
+    <EmbeddedResource Include="Scripts\GetNetstatCSV.sh">
+      <SubType>Content</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VSAC\Microsoft.SystemCenter.OperationsManager.targets" />
 </Project>

--- a/ManagementPacks/Community.DataOnDemand.Unix/ManagementPack.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/ManagementPack.mpx
@@ -14,8 +14,11 @@
               <maml:title>Summary</maml:title>
               <maml:para>Provides useful SCOM tasks for accessing data on demand from your environment.</maml:para>
               <maml:para>This MP provides tasks targeting Unix/Linux operating systems and components.</maml:para>
+            </maml:section>
+            <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+              <maml:title>External</maml:title>
               <maml:para>
-                Maintained at <maml:navigationLink>
+                <maml:navigationLink>
                   <maml:linkText>https://github.com/squaredup/Community.DataOnDemand.MP</maml:linkText>
                   <maml:uri href="https://github.com/squaredup/Community.DataOnDemand.MP" />
                 </maml:navigationLink>
@@ -23,7 +26,6 @@
             </maml:section>
           </MamlContent>
         </KnowledgeArticle>
-
       </KnowledgeArticles>
     </LanguagePack>
   </LanguagePacks>

--- a/ManagementPacks/Community.DataOnDemand.Unix/ManagementPack.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/ManagementPack.mpx
@@ -1,0 +1,30 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.Unix">
+          <Name>Data on Demand Unix/Linux - Community Management Pack</Name>
+          <Description>Provides useful SCOM tasks for accessing data on demand from your environment.  This MP contains Unix/Linux targeted tasks.  Maintained at https://github.com/squaredup/Community.DataOnDemand.MP</Description>
+        </DisplayString>
+      </DisplayStrings>
+      <KnowledgeArticles>
+        <KnowledgeArticle ElementID="Community.DataOnDemand.Unix" Visible="true">
+          <MamlContent>
+            <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+              <maml:title>Summary</maml:title>
+              <maml:para>Provides useful SCOM tasks for accessing data on demand from your environment.</maml:para>
+              <maml:para>This MP provides tasks targeting Unix/Linux operating systems and components.</maml:para>
+              <maml:para>
+                Maintained at <maml:navigationLink>
+                  <maml:linkText>https://github.com/squaredup/Community.DataOnDemand.MP</maml:linkText>
+                  <maml:uri href="https://github.com/squaredup/Community.DataOnDemand.MP" />
+                </maml:navigationLink>
+              </maml:para>
+            </maml:section>
+          </MamlContent>
+        </KnowledgeArticle>
+
+      </KnowledgeArticles>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -28,12 +28,12 @@
                 <Uri>http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem?__cimnamespace=root/scx</Uri>
                 <Selector/>
                 <InvokeAction>ExecuteScript</InvokeAction>
-                <Input><![CDATA[
-                    <p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+                <Input>
+                  <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
                     <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
                     <p:arguments>$Config/Format$</p:arguments>
                     <p:timeout>$Config/TimeoutSeconds$</p:timeout>
-                    </p:ExecuteScript_INPUT>]]>
+                  </p:ExecuteScript_INPUT>]]>
                 </Input>
               </ProbeAction>
             </MemberModules>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -54,7 +54,7 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv">
           <Name>Data On Demand GetNetstatCSV Probe</Name>
-          <Description>Displays established TCP connections collected via netstat -ano</Description>
+          <Description>Displays established TCP connections collected via netstat --tcp --numeric --program</Description>
         </DisplayString>
         <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv" SubElementID="Format">
           <Name>Output format</Name>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -1,0 +1,70 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <ModuleTypes>
+      <ProbeActionModuleType ID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv" Accessibility="Public" Batching="false">
+        <Configuration>
+          <xsd:element name="Format" minOccurs="1" maxOccurs="1">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="csv" />
+                <xsd:enumeration value="csvEx" />
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:element>
+          <xsd:element name="TargetSystem" type="xsd:string" minOccurs="1" maxOccurs="1" />
+          <xsd:element name="TimeoutSeconds" type="xsd:integer" minOccurs="1" maxOccurs="1"/>
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="Format" Selector="$Config/Format$" ParameterType="string"/>
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+        </OverrideableParameters>
+        <ModuleImplementation>
+          <Composite>
+            <MemberModules>
+              <ProbeAction ID="PassThru" TypeID="System!System.PassThroughProbe">
+              </ProbeAction>
+              <ProbeAction ID="Probe" TypeID="MUL!Microsoft.Unix.WSMan.Invoke.Privileged.ProbeAction">
+                <TargetSystem>$Config/TargetSystem$</TargetSystem>
+                <Uri>http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem?__cimnamespace=root/scx</Uri>
+                <Selector/>
+                <InvokeAction>ExecuteScript</InvokeAction>
+                <Input><![CDATA[
+                    <p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+                    <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
+                    <p:arguments>$Config/Format$</p:arguments>
+                    <p:timeout>$Config/TimeoutSeconds$</p:timeout>
+                    </p:ExecuteScript_INPUT>]]>
+                </Input>
+              </ProbeAction>
+            </MemberModules>
+            <Composition>
+              <Node ID="Probe">
+                <Node ID="PassThru" />
+              </Node>
+            </Composition>
+          </Composite>          
+        </ModuleImplementation>
+        <OutputType>MSWL!Microsoft.SystemCenter.WSManagement.WSManData</OutputType>
+        <TriggerOnly>true</TriggerOnly>
+      </ProbeActionModuleType>
+    </ModuleTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv">
+          <Name>Data On Demand GetNetstatCSV Probe</Name>
+          <Description>Displays established TCP connections collected via netstat -ano</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv" SubElementID="Format">
+          <Name>Output format</Name>
+          <Description>Allowed values: csv, csvEx</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv" SubElementID="TimeoutSeconds">
+          <Name>Timeout (Seconds)</Name>
+          <Description>The number of seconds before the script times out.</Description>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Provides netstat information in a format expected by Squared Up's Visual Application Discovery and Analysis feature.
+# Copyright 2016 Squared Up Limited, All Rights Reserved.
+# Argument Block
+# Arg 1 = Format
+Format="$1"
+if [ -z "$Format" ]; then
+	Format="csv"
+fi
+
+lineEnd=""
+case "$Format" in
+	csv)
+        lineEnd="\n"
+    csvEx)
+		lineEnd="%EOL%"
+	;;
+	*)
+		echo "Unknown format type $Format"
+		exit 1
+	;;
+esac
+
+# Print Header, required by SQUP provider
+echo -n "Computername,PID,ProcessName,ProcessDescription,Protocol,LocalAddress,LocalPort,RemoteAddress,RemotePort,State,RemoteAddressIP$lineEnd"
+
+# Output netstat info in required format.  -tpn gives us TCP only connections, without host/port lookup, and includes PIDs
+netstat -tpn |
+    grep ESTABLISHED |    
+    awk -v ORS="$lineEnd" -v OFS=',' '{
+        gsub(/:/, ",")
+        split($7,pid, "/")
+        split($5, remote, ",")
+        "ps -o args= --pid " pid[1] | getline args
+        sub(/^[^"].+[^"]$/, "\"&\"", args)
+        "ps -o comm= --pid " pid[1] | getline comm
+        print "'"$HOSTNAME"'", pid[1], comm, args, toupper($1), $4, $5, $6, remote[1]
+    }'
+
+exit

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -5,7 +5,7 @@
 # Arg 1 = Format
 Format="$1"
 if [ -z "$Format" ]; then
-	Format="csv"
+    Format="csv"
 fi
 
 # Store hostname in case it's not availible in certain shells
@@ -13,16 +13,16 @@ localHostName=$(hostname)
 
 lineEnd=""
 case "$Format" in
-	csv)
+    csv)
         lineEnd="\n"
-	;;
+    ;;
     csvEx)
-		lineEnd="%EOL%"
-	;;
-	*)
-		echo "Unknown format type $Format"
-		exit 1
-	;;
+        lineEnd="%EOL%"
+    ;;
+    *)
+        echo "Unknown format type $Format"
+        exit 1
+    ;;
 esac
 
 # Print Header, required by SQUP provider

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -8,10 +8,14 @@ if [ -z "$Format" ]; then
 	Format="csv"
 fi
 
+# Store hostname in case it's not availible in certain shells
+localHostName=$(hostname)
+
 lineEnd=""
 case "$Format" in
 	csv)
         lineEnd="\n"
+	;;
     csvEx)
 		lineEnd="%EOL%"
 	;;
@@ -32,9 +36,9 @@ netstat -tpn |
         split($7,pid, "/")
         split($5, remote, ",")
         "ps -o args= --pid " pid[1] | getline args
-        sub(/^[^"].+[^"]$/, "\"&\"", args)
+        sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
         "ps -o comm= --pid " pid[1] | getline comm
-        print "'"$HOSTNAME"'", pid[1], comm, args, toupper($1), $4, $5, $6, remote[1]
+        print "'"$localHostName"'", pid[1], comm, args, toupper($1), $4, $5, $6, remote[1]
     }'
 
 exit

--- a/ManagementPacks/Community.DataOnDemand.Unix/Tasks/GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Tasks/GetNetstatCsv.mpx
@@ -1,0 +1,24 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Monitoring>
+    <Tasks>
+      <Task ID="Community.DataOnDemand.Unix.Task.GetNetstatCsv" Accessibility="Public" Timeout="60" Enabled="true" Remotable="false" Target="MUL!Microsoft.Unix.Computer">
+        <Category>Operations</Category>
+        <ProbeAction ID="Probe" TypeID="Community.DataOnDemand.Unix.Probe.GetNetstatCsv">
+          <Format>csvEx</Format>
+          <TargetSystem>$Target/Property[Type='MUL!Microsoft.Unix.Computer']/NetworkName$</TargetSystem>
+          <TimeoutSeconds>60</TimeoutSeconds>
+        </ProbeAction>
+      </Task>
+    </Tasks>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.Unix.Task.GetNetstatCsv">
+          <Name>Get Netstat CSV (Data On Demand)</Name>
+          <Description>Displays established TCP connections on the target computer.</Description>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/Community.DataOnDemand/ManagementPack.mpx
+++ b/ManagementPacks/Community.DataOnDemand/ManagementPack.mpx
@@ -1,5 +1,4 @@
 ﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-
   <LanguagePacks>
     <LanguagePack ID="ENU" IsDefault="true">
       <DisplayStrings>
@@ -14,13 +13,19 @@
             <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
               <maml:title>Summary</maml:title>
               <maml:para>Provides useful SCOM tasks for accessing data on demand from your environment.</maml:para>
-              <maml:para>Maintained at <maml:navigationLink><maml:linkText>https://github.com/squaredup/Community.DataOnDemand.MP</maml:linkText><maml:uri href="https://github.com/squaredup/Community.DataOnDemand.MP" /></maml:navigationLink></maml:para>
+            </maml:section>
+            <maml:section xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+              <maml:title>External</maml:title>
+              <maml:para>
+                <maml:navigationLink>
+                  <maml:linkText>https://github.com/squaredup/Community.DataOnDemand.MP</maml:linkText>
+                  <maml:uri href="https://github.com/squaredup/Community.DataOnDemand.MP" />
+                </maml:navigationLink>
+              </maml:para>
             </maml:section>
           </MamlContent>
         </KnowledgeArticle>
-
       </KnowledgeArticles>
     </LanguagePack>
   </LanguagePacks>
-  
 </ManagementPackFragment>

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Display Name                     | Target           | Description
 -------------------------------- | ---------------- | ----------------------
 Get DNS Cache (Data On Demand)   | Windows Computer | Lists all entries in the server's DNS cache.
 List Event Logs (Data On Demand) | Windows Computer | Displays the last 4 entries in the system event log.
-Get Netstat (Data On Demand)     | Windows Computer | Displays established TCP connections using netstat.
+Get Netstat CSV (Data On Demand) | Windows Computer | Displays established TCP connections using netstat.
 List Processes (Data On Demand)  | Windows Computer | Lists the top 10 processes sorted by CPU usage.
 List Services (Data On Demand)   | Windows Computer | Lists the name and status of services.
+Get Netstat CSV (Data On Demand) | Unix Computer    | Displays established TCP connections using netstat.
 
 ## Help and Assistance
 


### PR DESCRIPTION
This PR provides support for getting CSV data from Unix/Linux hosts commonly found in SCOM.

## Changes
- Added a Unix management pack to the solution so we can provide functionality to nix workloads without forcing the import of Unix Library MPs for everyone who wants to use the Data On Demand MP set.
- Added a SCOM task for getting Netstat data that is supported on RHEL, Ubuntu, SLES, CentOS and Oracle linux.

## Issues Addressed
- #1 

## Breaking Changes
None.