### PR TITLE
Call out lack of json support on Windows hosts without PowerShell v3 or later.

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
@@ -15,7 +15,8 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.GetDnsClientCache">
           <Name>Get DNS Cache (Data On Demand)</Name>
-          <Description>Displays the contents of the DNS cache on the target computer.</Description>
+          <Description>Displays the contents of the DNS cache on the target computer.  
+          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetDnsClientCache.mpx
@@ -16,7 +16,7 @@
         <DisplayString ElementID="Community.DataOnDemand.GetDnsClientCache">
           <Name>Get DNS Cache (Data On Demand)</Name>
           <Description>Displays the contents of the DNS cache on the target computer.  
-          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
+          Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
@@ -20,7 +20,8 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.GetEventLogs">
           <Name>List Event Logs (Data On Demand)</Name>
-          <Description>Displays the top 4 system event log entries on the target computer.</Description>
+          <Description>Displays the top 4 system event log entries on the target computer.  
+          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetEventLogs.mpx
@@ -21,7 +21,7 @@
         <DisplayString ElementID="Community.DataOnDemand.GetEventLogs">
           <Name>List Event Logs (Data On Demand)</Name>
           <Description>Displays the top 4 system event log entries on the target computer.  
-          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
+          Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
@@ -16,7 +16,7 @@
         <DisplayString ElementID="Community.DataOnDemand.GetNetstatCsv">
           <Name>Get Netstat CSV (Data On Demand)</Name>
           <Description>Displays established TCP connections on the target computer.  
-          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
+          Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetNetstatCsv.mpx
@@ -15,7 +15,8 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.GetNetstatCsv">
           <Name>Get Netstat CSV (Data On Demand)</Name>
-          <Description>Displays established TCP connections on the target computer.</Description>
+          <Description>Displays established TCP connections on the target computer.  
+          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
@@ -18,7 +18,8 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.GetProcesses">
           <Name>List Processes (Data On Demand)</Name>
-          <Description>Displays the top 10 CPU consuming processes on the target computer.</Description>
+          <Description>Displays the top 10 CPU consuming processes on the target computer.  
+          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetProcesses.mpx
@@ -19,7 +19,7 @@
         <DisplayString ElementID="Community.DataOnDemand.GetProcesses">
           <Name>List Processes (Data On Demand)</Name>
           <Description>Displays the top 10 CPU consuming processes on the target computer.  
-          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
+          Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetServices.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetServices.mpx
@@ -15,7 +15,8 @@
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.GetServices">
           <Name>List Services (Data On Demand)</Name>
-          <Description>Displays services and their status on the target computer.</Description>
+          <Description>Displays services and their status on the target computer.  
+          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetServices.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetServices.mpx
@@ -16,7 +16,7 @@
         <DisplayString ElementID="Community.DataOnDemand.GetServices">
           <Name>List Services (Data On Demand)</Name>
           <Description>Displays services and their status on the target computer.  
-          Note: json format is only supported if PowerShell v3 or later is installed on the target server.</Description>
+          Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.</Description>
         </DisplayString>
       </DisplayStrings>
     </LanguagePack>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Get Netstat (Data On Demand)     | Windows Computer | Displays established TCP c
 List Processes (Data On Demand)  | Windows Computer | Lists the top 10 processes sorted by CPU usage.
 List Services (Data On Demand)   | Windows Computer | Lists the name and status of services.
 
-**Note** Windows tasks support returning data in json, however this is only supported if PowerShell v3 or later are availible on the target agent.
+**Note:** Windows tasks support returning data in json, however this is only supported if PowerShell v3 or later are availible on the target agent.
 
 ## Help and Assistance
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Get Netstat (Data On Demand)     | Windows Computer | Displays established TCP c
 List Processes (Data On Demand)  | Windows Computer | Lists the top 10 processes sorted by CPU usage.
 List Services (Data On Demand)   | Windows Computer | Lists the name and status of services.
 
-**Note:** Windows tasks support returning data in json, however this is only supported if PowerShell v3 or later are availible on the target agent.
+**Note:** Windows tasks support returning data in JSON, however this is only supported if PowerShell v3 or later are availible on the target agent.
 
 ## Help and Assistance
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Get Netstat (Data On Demand)     | Windows Computer | Displays established TCP c
 List Processes (Data On Demand)  | Windows Computer | Lists the top 10 processes sorted by CPU usage.
 List Services (Data On Demand)   | Windows Computer | Lists the name and status of services.
 
+**Note** Windows tasks support returning data in json, however this is only supported if PowerShell v3 or later are availible on the target agent.
+
 ## Help and Assistance
 
 This management pack is a community management originally developed by Squared Up (<http://www.squaredup.com>).


### PR DESCRIPTION
This PR attempts to mitigate Issue #7 by including a note regarding json format support in the task description and MP readme.