### PR TITLE
Limit length of process description field in Netstat task results

### DIFF
--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -35,9 +35,11 @@ netstat -tpn |
         gsub(/:/, ",")
         split($7,pid, "/")
         split($5, remote, ",")
-        argQuery = "ps -o args= --pid " pid[1] " | cut -c-256"
+        argQuery = "ps -o args= --pid " pid[1] " | cut -c-128"
         argQuery | getline args
         close(argQuery)
+        if (length(args) == 128 &amp;&amp; substr(args,length(args)-2,3))
+            args = args "..."
         sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
         commandQuery = "ps -o comm= --pid " pid[1]
         commandQuery | getline comm

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -10,6 +10,7 @@ fi
 
 # Store hostname in case it's not availible in certain shells
 localHostName=$(hostname)
+processDescMaxLength=128
 
 lineEnd=""
 case "$Format" in
@@ -31,14 +32,14 @@ echo -n "Computername,PID,ProcessName,ProcessDescription,Protocol,LocalAddress,L
 # Output netstat info in required format.  -tpn gives us TCP only connections, without host/port lookup, and includes PIDs
 netstat -tpn |
     grep ESTABLISHED |    
-    awk -v ORS="$lineEnd" -v OFS=',' '{
+    awk -v ORS="$lineEnd" -v OFS=',' -v processDescMaxLength=$processDescMaxLength '{
         gsub(/:/, ",")
         split($7,pid, "/")
         split($5, remote, ",")
-        argQuery = "ps -o args= --pid " pid[1] " | cut -c-128"
+        argQuery = "ps -o args= --pid " pid[1] " | cut -c-" processDescMaxLength
         argQuery | getline args
         close(argQuery)
-        if (length(args) == 128 &amp;&amp; substr(args,length(args)-2,3))
+        if (length(args) == processDescMaxLength &amp;&amp; substr(args,length(args)-2,3))
             args = args "..."
         sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
         commandQuery = "ps -o comm= --pid " pid[1]

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -35,9 +35,13 @@ netstat -tpn |
         gsub(/:/, ",")
         split($7,pid, "/")
         split($5, remote, ",")
-        "ps -o args= --pid " pid[1] | getline args
+        argQuery = "ps -o args= --pid " pid[1] " | cut -c-256"
+        argQuery | getline args
+        close(argQuery)
         sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
-        "ps -o comm= --pid " pid[1] | getline comm
+        commandQuery = "ps -o comm= --pid " pid[1]
+        commandQuery | getline comm
+        close(commandQuery)
         print "'"$localHostName"'", pid[1], comm, args, toupper($1), $4, $5, $6, remote[1]
     }'
 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -166,7 +166,8 @@ foreach ($line in $results) {
     }
 
     # CSV escape procDesc and shorten
-    $procDesc = '"' + ($procDesc.Substring(0,256) -replace '"','""') + '"'
+    $procDesc = $procDesc.Substring(0, [System.Math]::Min(256,$procDesc.length))
+    $procDesc = '"' + ($procDesc -replace '"','""') + '"'
 
     # Emit a CSV line for our consumer...
     $output += '{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}%EOL%' -f `

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -165,13 +165,12 @@ foreach ($line in $results) {
         $dnsName = $dnsCache[$addrs[2]]
     }
 
-    # CSV escape procDesc and shorten
+    # CSV escape procDesc and shorten, appending ... if not already present
     $maxlength = 128
-    $procDesc = $procDesc.Substring(0, [System.Math]::Min($maxlength,$procDesc.length))
-    if ($procDesc.length -eq $maxlength -and $procDesc -notmatch '\.{3}$') {
-        $procDesc = "$procDesc..."
+    if ($procDesc.length -gt $maxlength) {
+        $procDesc = $procDesc.Substring(0, $maxlength) -replace '(?<!\.{3})$','...'
     }
-    $procDesc = '"' + ($procDesc -replace '"','""') + '"'
+    $procDesc = '"' + $procDesc.Replace('"','""') + '"'
 
     # Emit a CSV line for our consumer...
     $output += '{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}%EOL%' -f `

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -166,7 +166,11 @@ foreach ($line in $results) {
     }
 
     # CSV escape procDesc and shorten
-    $procDesc = $procDesc.Substring(0, [System.Math]::Min(256,$procDesc.length))
+    $maxlength = 128
+    $procDesc = $procDesc.Substring(0, [System.Math]::Min($maxlength,$procDesc.length))
+    if ($procDesc.length -eq $maxlength -and $procDesc -notmatch '\.{3}$') {
+        $procDesc = "$procDesc..."
+    }
     $procDesc = '"' + ($procDesc -replace '"','""') + '"'
 
     # Emit a CSV line for our consumer...

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -165,8 +165,8 @@ foreach ($line in $results) {
         $dnsName = $dnsCache[$addrs[2]]
     }
 
-    # CSV escape procDesc
-    $procDesc = '"' + ($procDesc -replace '"','""') + '"'
+    # CSV escape procDesc and shorten
+    $procDesc = '"' + ($procDesc.Substring(0,256) -replace '"','""') + '"'
 
     # Emit a CSV line for our consumer...
     $output += '{0},{1},{2},{3},{4},{5},{6},{7},{8},{9},{10}%EOL%' -f `


### PR DESCRIPTION
This PR will limit the Process description field in Netstat data to ~128 characters.  The datablock may actually be longer due to quote escaping, but this should still significantly cut down on task result size when the process description was previously 5000+ chars for some users.

On Linux, Substr and length are both standard functions of AWK and should be available everywhere we were already targeting, and cut is part of SUS and likewise shouldn't introduce any issues.

This PR resolves issue #16 