### PR TITLE
#20 Prevent process description from being set to a null value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# Visual Studio Code
+/.vscode/launch.json
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -8,6 +8,10 @@
     CSV form friendly to automated consumption.
 .PARAMETER Format
     Permitted values: text, csv, json
+.EXAMPLE
+	PS > .\Get-Netstat.ps1 -format csv
+
+	Returns netstat information in the default CSV format.
 .NOTES
     netsh is used to find out which ports are being listened to by
     http.sys.  Any TCP connections to such ports have their process
@@ -18,8 +22,11 @@
     Output is sent to Write-Host to simplify consumption of output
     when run as a SCOM agent task.
 
-    Copyright 2016 Squared Up Limited, All Rights Reserved.
+    Copyright 2017 Squared Up Limited, All Rights Reserved.
+.LINK
+	https://www.squaredup.com
 #>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
 Param(
     [ValidateSet("text","csv","csvEx","json","list")]
     [string] $Format = "csv"
@@ -59,7 +66,7 @@ $trueByHttpSysPort = @{}
 
 $data = @()
 netsh http show servicestate verbose=yes view=requestq | ForEach-Object {
-    $data += $_
+    $script:data += $_
 }
 for( $i = 0; $i -lt $data.Length; $i++) {
 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -153,7 +153,7 @@ foreach ($line in $results) {
         }
         else
         {
-            if ($proc.MainModule -and $proc.MainModule.FileVersionInfo) {
+            if ($proc.MainModule -and $proc.MainModule.FileVersionInfo -and $proc.MainModule.FileVersionInfo.FileDescription) {
                 $procDesc = $proc.MainModule.FileVersionInfo.FileDescription
             }
         }


### PR DESCRIPTION
Since procDesc is already initialized to a string, we now simply test if the file description is null prior to attempting to set the value.

This PR also adds an exclusion to gitignore for a file for VSCode (debugging of PowerShell) and some fixes for PowerShell best practice violations.

Fixes Issue #20 