### PR TITLE
Support kernel owned connections and secured environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bld/
 # Visual Studio Code
 /.vscode/launch.json
 /.vscode/tasks.json
+/.vscode/settings.json
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ bld/
 
 # Visual Studio Code
 /.vscode/launch.json
+/.vscode/tasks.json
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/ManagementPacks/Community.DataOnDemand.Unix/Community.DataOnDemand.Unix.mpproj
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Community.DataOnDemand.Unix.mpproj
@@ -49,7 +49,7 @@
     </ManagementPackReference>
     <ManagementPackReference Include="Microsoft.Windows.Library">
       <Alias>Windows</Alias>
-      <PackageToBundle>false</PackageToBundle>
+      <PackageToBundle>False</PackageToBundle>
     </ManagementPackReference>
     <ManagementPackReference Include="System.Health.Library">
       <Alias>Health</Alias>
@@ -76,6 +76,9 @@
     <Compile Include="Modules\Probe.GetNetstatCsv.mpx">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Modules\Probe.ExtractUserFromProfile.mpx">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Modules\Probe.ResolveAddress.mpx">
       <SubType>Code</SubType>
     </Compile>
@@ -92,6 +95,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Scripts\ExtractUserFromProfile.ps1" />
     <EmbeddedResource Include="Scripts\ResolveAddress.pl">
       <SubType>Content</SubType>
     </EmbeddedResource>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.ExtractUserFromProfile.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.ExtractUserFromProfile.mpx
@@ -1,0 +1,43 @@
+﻿<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TypeDefinitions>
+    <ModuleTypes>
+      <ProbeActionModuleType ID="Community.DataOnDemand.Unix.Probe.ExtractUserFromProfile" Accessibility="Public" Batching="false" PassThrough="false">
+        <Configuration>
+          <xsd:element name="User" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+        </Configuration>
+        <ModuleImplementation>
+          <Composite>
+            <MemberModules>
+              <ProbeAction ID="Probe" TypeID="Windows!Microsoft.Windows.PowerShellPropertyBagTriggerOnlyProbe">
+                <ScriptName>ExtractUserFromProfile.ps1</ScriptName>
+                <ScriptBody>$IncludeFileContent/Scripts/ExtractUserFromProfile.ps1$</ScriptBody>
+                <Parameters>
+                  <Parameter>
+                    <Name>user</Name>
+                    <Value>$Config/User$</Value>
+                  </Parameter>
+                </Parameters>
+                <TimeoutSeconds>60</TimeoutSeconds>
+              </ProbeAction>              
+            </MemberModules>
+            <Composition>
+              <Node ID="Probe" />                
+            </Composition>
+          </Composite>
+        </ModuleImplementation>
+        <OutputType>System!System.PropertyBagData</OutputType>
+        <TriggerOnly>true</TriggerOnly>
+      </ProbeActionModuleType>
+    </ModuleTypes>
+  </TypeDefinitions>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.Unix.Probe.ExtractUserFromProfile">
+          <Name>Data On Demand Extract user from Run As profile Probe</Name>
+          <Description>Extracts the UserName only from a Unix/Linux Run as account binding</Description>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -21,25 +21,42 @@
         <ModuleImplementation>
           <Composite>
             <MemberModules>
-              <ProbeAction ID="PassThru" TypeID="System!System.PassThroughProbe">
+              <ProbeAction ID="ExtractUser" TypeID="Community.DataOnDemand.Unix.Probe.ExtractUserFromProfile">
+                <User>$RunAs[Name="MUL!Microsoft.Unix.PrivilegedAccount"]/UserName$</User>
               </ProbeAction>
-              <ProbeAction ID="Probe" TypeID="MUL!Microsoft.Unix.WSMan.Invoke.Privileged.ProbeAction">
-                <TargetSystem>$Config/TargetSystem$</TargetSystem>
-                <Uri>http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem?__cimnamespace=root/scx</Uri>
-                <Selector/>
-                <InvokeAction>ExecuteScript</InvokeAction>
-                <Input>
-                  <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
+              <ProbeAction ID="Probe" TypeID="MSWL!Microsoft.SystemCenter.WSManagement.Invoker">
+                <Invoke>
+                  <Protocol>https</Protocol>
+                  <TargetSystem>$Config/TargetSystem$</TargetSystem>
+                  <Port>1270</Port>
+                  <Authentication>basic</Authentication>
+                  <UserName>$Data/Property[@Name='User']$</UserName>
+                  <Password>$RunAs[Name="MUL!Microsoft.Unix.PrivilegedAccount"]/Password$</Password>
+                  <SkipCACheck>false</SkipCACheck>
+                  <SkipCNCheck>false</SkipCNCheck>
+                  <OutputErrorIfAny>true</OutputErrorIfAny>
+                  <UTF>utf-8</UTF>
+                  <Uri>http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem?__cimnamespace=root/scx</Uri>
+                  <Selector/>
+                  <InvokeAction>ExecuteScript</InvokeAction>
+                  <Input>
+                    <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
                     <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
                     <p:arguments>$Config/Format$</p:arguments>
                     <p:timeout>$Config/TimeoutSeconds$</p:timeout>
+                    <p:ElevationType></p:ElevationType>
                   </p:ExecuteScript_INPUT>]]>
-                </Input>
+                  </Input>
+                  <TimeOutInMS>120000</TimeOutInMS>
+                  <EventPolicy>
+                    <EventOnConnectionErrors>false</EventOnConnectionErrors>
+                  </EventPolicy>
+                </Invoke>
               </ProbeAction>
             </MemberModules>
             <Composition>
               <Node ID="Probe">
-                <Node ID="PassThru" />
+                <Node ID="ExtractUser"/>
               </Node>
             </Composition>
           </Composite>          

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -31,7 +31,7 @@
                 <Input>
                   <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
                     <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
-                    <p:arguments>"$Config/Format$" "$RunAs[Name="Microsoft.Unix.PrivilegedAccount"]/UserName$"</p:arguments>
+                    <p:arguments>"$Config/Format$" "$RunAs[Name="MUL!Microsoft.Unix.PrivilegedAccount"]/UserName$"</p:arguments>
                     <p:timeout>$Config/TimeoutSeconds$</p:timeout>
                   </p:ExecuteScript_INPUT>]]>
                 </Input>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -31,7 +31,7 @@
                 <Input>
                   <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
                     <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
-                    <p:arguments>"$Config/Format$" "$RunAs[Name="MUL!Microsoft.Unix.PrivilegedAccount"]/UserName$"</p:arguments>
+                    <p:arguments>$Config/Format$</p:arguments>
                     <p:timeout>$Config/TimeoutSeconds$</p:timeout>
                   </p:ExecuteScript_INPUT>]]>
                 </Input>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Modules/Probe.GetNetstatCsv.mpx
@@ -31,7 +31,7 @@
                 <Input>
                   <![CDATA[<p:ExecuteScript_INPUT xmlns:p="http://schemas.microsoft.com/wbem/wscim/1/cim-schema/2/SCX_OperatingSystem">
                     <p:script>$IncludeFileContent/Scripts/GetNetstatCSV.sh$</p:script>
-                    <p:arguments>$Config/Format$</p:arguments>
+                    <p:arguments>"$Config/Format$" "$RunAs[Name="Microsoft.Unix.PrivilegedAccount"]/UserName$"</p:arguments>
                     <p:timeout>$Config/TimeoutSeconds$</p:timeout>
                   </p:ExecuteScript_INPUT>]]>
                 </Input>

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/ExtractUserFromProfile.ps1
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/ExtractUserFromProfile.ps1
@@ -1,0 +1,24 @@
+﻿# Extract username from a Unix/Linux run as profile prior to passing to the Microsoft.SystemCenter.WSManagement.Invoker
+Param(
+	$user
+)
+
+$scomAPI = New-Object -ComObject "MOM.ScriptAPI"
+$propertyBag = $scomAPI.CreatePropertyBag()
+
+if ([string]::IsNullOrEmpty($user))
+{
+	$propertyBag.AddValue("User", "")	
+}
+elseif ($user -match '<UserId>.+</UserId>')
+{
+	$modifiedUser = $user -replace '.*<UserId>([^<]+)</UserId>.*','$1'
+	$propertyBag.AddValue("User", "$modifiedUser")	 
+}
+else
+{
+	$propertyBag.AddValue("User", $user)
+}
+
+# Send output to SCOM    
+$propertyBag

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -57,7 +57,7 @@ awkScript='{
         else
         {
             # Query for command (with args) that started the process
-            argQuery = elevate "ps -o args= --pid " pid[1] " | cut -c-" processDescMaxLength
+            argQuery = elevate " ps -o args= --pid " pid[1] " | cut -c-" processDescMaxLength
             argQuery | getline args
             close(argQuery)
 
@@ -70,7 +70,7 @@ awkScript='{
             sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
             
             # Query for the process name
-            commandQuery = elevate "ps -o comm= --pid " pid[1]
+            commandQuery = elevate " ps -o comm= --pid " pid[1]
             commandQuery | getline comm
             close(commandQuery)
         }

--- a/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
+++ b/ManagementPacks/Community.DataOnDemand.Unix/Scripts/GetNetstatCSV.sh
@@ -3,10 +3,13 @@
 # Copyright 2016 Squared Up Limited, All Rights Reserved.
 # Argument Block
 # Arg 1 = Format
+# Arg 2 = SCXUser configuration
 Format="$1"
 if [ -z "$Format" ]; then
     Format="csv"
 fi
+
+scxUser="$2"
 
 # Store hostname in case it's not availible in certain shells
 localHostName=$(hostname)
@@ -26,13 +29,18 @@ case "$Format" in
     ;;
 esac
 
-# Print Header, required by SQUP provider
-echo -n "Computername,PID,ProcessName,ProcessDescription,Protocol,LocalAddress,LocalPort,RemoteAddress,RemotePort,State,RemoteAddressIP$lineEnd"
+elevate=""
+if [ "$(id -u)" != "0" ]; then
+    # Not currently running as root, check if we are supposed to elevate or not    
+    case "$scxUser" in        
+        *\&lt;Elev\&gt;sudo\&lt;/Elev\&gt;*)
+            elevate="sudo"        
+        ;;
+    esac
+fi
 
-# Output netstat info in required format.  -tpn gives us TCP only connections, without host/port lookup, and includes PIDs
-netstat -tpn |
-    grep ESTABLISHED |    
-    awk -v ORS="$lineEnd" -v OFS=',' -v processDescMaxLength=$processDescMaxLength '{
+# Store AWK script 
+awkScript='{
         # Local Endpoint Address / Port split
         localEpSplit = match($4, ":[0-9]+$")
         localAddr = substr($4, 0, localEpSplit - 1)
@@ -45,27 +53,51 @@ netstat -tpn |
 
         # Extract PID
         split($7,pid, "/")        
-        
-        # Query for command (with args) that started the process
-        argQuery = "ps -o args= --pid " pid[1] " | cut -c-" processDescMaxLength
-        argQuery | getline args
-        close(argQuery)
 
-        # Append "..." if the string is max length and does not already end with those characters
-        if (length(args) == processDescMaxLength &amp;&amp; substr(args,length(args)-2,3) != "...")
-            args = args "..."
-        
-        # Escape double quotes, then Wrap the description in double quotes for CSV
-        gsub(/"/, "\"\"", args)
-        sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
-        
-        # Query for the process name
-        commandQuery = "ps -o comm= --pid " pid[1]
-        commandQuery | getline comm
-        close(commandQuery)
+        if (pid[1] == "-" || pid[1] == "") 
+        {
+            comm = "Unknown"
+            args = ""
+            pid[1] = -1
+
+        }
+        else
+        {
+            # Query for command (with args) that started the process
+            argQuery = elevate "ps -o args= --pid " pid[1] " | cut -c-" processDescMaxLength
+            argQuery | getline args
+            close(argQuery)
+
+            # Append "..." if the string is max length and does not already end with those characters
+            if (length(args) == processDescMaxLength &amp;&amp; substr(args,length(args)-2,3) != "...")
+                args = args "..."
+            
+            # Escape double quotes, then Wrap the description in double quotes for CSV
+            gsub(/"/, "\"\"", args)
+            sub(/^[^"].+[^"]$/, "\"&amp;\"", args)
+            
+            # Query for the process name
+            commandQuery = elevate "ps -o comm= --pid " pid[1]
+            commandQuery | getline comm
+            close(commandQuery)
+        }
 
         # Finally, print records
         print "'"$localHostName"'", pid[1], comm, args, toupper($1), localAddr, localPort, remoteAddr, remotePort, $6, remoteAddr
-    }'
+}'
+
+# Print Header, required by SQUP provider
+echo -n "Computername,PID,ProcessName,ProcessDescription,Protocol,LocalAddress,LocalPort,RemoteAddress,RemotePort,State,RemoteAddressIP$lineEnd"
+
+# Output netstat info in required format.  -tpn gives us TCP only connections, without host/port lookup, and includes PIDs
+if [ "$elevate" != "sudo" ]; then
+    netstat -tpn |
+        grep ESTABLISHED |    
+            awk -v ORS="$lineEnd" -v OFS=',' -v processDescMaxLength=$processDescMaxLength -v elevate="" "$awkScript"
+else
+    sudo netstat -tpn |
+        grep ESTABLISHED |    
+            awk -v ORS="$lineEnd" -v OFS=',' -v processDescMaxLength=$processDescMaxLength -v elevate="sudo " "$awkScript"
+fi
 
 exit


### PR DESCRIPTION
This PR attempts to kill two (similar) birds with one stone.  The first is that support has been enabled for kernal owned connections - we'll now report these as unknown processes (as per windows) with a PID value of -1 (0 is a valid number on nix, and -1 is accepted as a PID but reserved specifically for error states).  This allows VADA to correctly model the connections on this node, even if we can't correlate the owning component.

The other (larger) change here is support for environments were sudo elevation is required, but the Linux admin is (rightly) not happy to allow the SCOM account to run any command in /tmp/ elevated.  Thankfully the solution turned out to be much simpler than it could have been, but as is normal poor documentation and an inflexible API made coming up with that solution pretty difficult.

This PR addresses issue #24 