### PR TITLE
Change for output ordering of sorted property 

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -52,7 +52,7 @@ $EventLogs = Get-EventLog @Params
 
 # Get properties of object to be displayed in output
 [System.Collections.ArrayList]$OutPutOrdering = $EventLogs | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
-# Add proprty being sorted on to list of properties (will generate duplicate entry)
+# Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,"TimeGenerated") 
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -53,7 +53,7 @@ $EventLogs = Get-EventLog @Params
 # Get properties of object to be displayed in output
 [System.Collections.ArrayList]$OutPutOrdering = $EventLogs | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
 # Add proprty being sorted on to list of properties (will generate duplicate entry)
-$OutPutOrderings.Insert(0,"TimeGenerated") 
+$OutPutOrdering.Insert(0,"TimeGenerated") 
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique
 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -53,9 +53,9 @@ $EventLogs = Get-EventLog @Params
 # Get properties of object to be displayed in output
 [System.Collections.ArrayList]$OutPutOrdering = $EventLogs | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
 # Add proprty being sorted on to list of properties (will generate duplicate entry)
-$DefaultProOutPutOrderingperties.Insert(0,"TimeGenerated") 
+$OutPutOrderings.Insert(0,"TimeGenerated") 
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
-$OutPutOrdering = $DefaultPrOutPutOrderingoperties | Select-Object -Unique
+$OutPutOrdering = $OutPutOrdering | Select-Object -Unique
 
 if ($Format -eq 'text')
 {

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -50,7 +50,7 @@ if ($EntryType) {
 
 $EventLogs = Get-EventLog @Params
 
-# Get properties of object to be displayed in output
+# Get properties of object to be displayed in output (Get-Memeber does not honor order of properties in object)
 [System.Collections.ArrayList]$OutPutOrdering = $EventLogs | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,"TimeGenerated") 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -70,6 +70,7 @@ elseif ($Format -eq 'csv')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
+        | Select-Object -Property $OutPutOrdering `
         | ConvertTo-Csv -NoTypeInformation `
         | Out-String -Width 4096 `
         | Write-Host
@@ -78,6 +79,7 @@ elseif ($Format -eq 'json')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
+        | Select-Object -Property $OutPutOrdering `
         | ConvertTo-Json `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-EventLogs.ps1
@@ -50,10 +50,18 @@ if ($EntryType) {
 
 $EventLogs = Get-EventLog @Params
 
+# Get properties of object to be displayed in output
+[System.Collections.ArrayList]$OutPutOrdering = $EventLogs | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
+# Add proprty being sorted on to list of properties (will generate duplicate entry)
+$DefaultProOutPutOrderingperties.Insert(0,"TimeGenerated") 
+# Remove the duplicate from the list of properties (will preserve the first one in the list)
+$OutPutOrdering = $DefaultPrOutPutOrderingoperties | Select-Object -Unique
+
 if ($Format -eq 'text')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
+        | Select-Object -Property $OutPutOrdering `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
@@ -78,6 +86,7 @@ elseif ($format -eq 'list')
 {
     $EventLogs `
         | Sort-Object -Property TimeGenerated -Descending `
+        | Select-Object -Property $OutPutOrdering `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -64,13 +64,15 @@ foreach ($PoshProcess in $PoshProcesses)
         "Handles"=$WmiProcess.HandleCount;
         "Threads"=$WmiProcess.ThreadCount;
     }
+    
 }
-
+# Change the display order based on user selected property being sorted on
+$OutputOrdering = @($OrderBy,"Pid", "Name", "CpuPercent", "PrivateBytes", "Description", "ParentPid", "SessionId", "Handles", "Threads") | Select-Object -Unique
 if ($Format -eq 'text')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
+        | Select-Object -First $Top -Property $OutputOrdering `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
@@ -97,7 +99,7 @@ elseif ($Format -eq 'list')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top Pid, Name, CpuPercent, PrivateBytes, Description, ParentPid, SessionId, Handles, Threads `
+        | Select-Object -First $Top -Property $OutputOrdering `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -15,6 +15,7 @@
     Copyright 2016 Squared Up Limited, All Rights Reserved.
 #>
 Param(
+    [ValidateSet("Pid","Name","CpuPercent","PrivateBytes","Description","ParentPid","SessionId","Handles","Threads","Path")]
     [string] $OrderBy = "Pid",
     $Descending = $false,
     [int] $Top = "99999",

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -51,7 +51,7 @@ foreach ($PoshProcess in $PoshProcesses)
         continue;
     }
 
-    # Create a set of output objects with properties from WMI and posh
+    # Create a set of output objects with properties from WMI and posh with specific ordering of properties
     $OutputObject = New-Object -TypeName PSObject
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Pid -Value $PoshProcess.Id
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Name -Value $PoshProcess.Name
@@ -65,13 +65,13 @@ foreach ($PoshProcess in $PoshProcesses)
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Path -Value $PoshProcess.Path
 
     $OutputObjects += $OutputObject
-    # Do not null OutputObject object it is used further down to extract correct ordering of object properties
+    $OutputObject = $Null
 }
 
 
 # Get properties of object to be displayed in output, note OutputObject must by used as OutputObjects gives strange return
 # Get-Member can not be used here as it does not perserve the property order in the object
-[System.Collections.ArrayList]$OutPutOrdering = $OutputObject.psobject.Properties.Name
+[System.Collections.ArrayList]$OutPutOrdering = $OutputObjects[0].psobject.Properties | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,$OrderBy)
 # Remove the duplicate from the list of properties (will preserve the first one in the list)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -69,7 +69,7 @@ foreach ($PoshProcess in $PoshProcesses)
 }
 
 
-# Get properties of object to be displayed in output, note OutputObject must by used as OutputObjects gives strange return
+# Get properties of object to be displayed in output
 # Get-Member can not be used here as it does not perserve the property order in the object
 [System.Collections.ArrayList]$OutPutOrdering = $OutputObjects[0].psobject.Properties | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -65,8 +65,7 @@ foreach ($PoshProcess in $PoshProcesses)
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Path -Value $PoshProcess.Path
 
     $OutputObjects += $OutputObject
-    # Do not null object it is used further down to extract correct ordering of object properties
-    #$OutputObject = $Null
+    # Do not null OutputObject object it is used further down to extract correct ordering of object properties
 }
 
 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -52,27 +52,36 @@ foreach ($PoshProcess in $PoshProcesses)
     }
 
     # Create a set of output objects with properties from WMI and posh
-    $OutputObjects += New-Object -TypeName PSObject -Property @{
-        "Pid"=$PoshProcess.Id;
-        "ParentPid"=$WmiProcess.CreatingProcessID;
-        "SessionId"=$PoshProcess.SessionId;
-        "Name"=$PoshProcess.Name;
-        "Description"=$PoshProcess.Description;
-        "Path"=$PoshProcess.Path;
-        "CpuPercent"=$WmiProcess.PercentProcessorTime;
-        "PrivateBytes"=$WmiProcess.PrivateBytes;
-        "Handles"=$WmiProcess.HandleCount;
-        "Threads"=$WmiProcess.ThreadCount;
-    }
-    
+    $OutputObject = New-Object -TypeName PSObject
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Pid -Value $PoshProcess.Id
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Name -Value $PoshProcess.Name
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name CpuPercent -Value $WmiProcess.PercentProcessorTime
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name PrivateBytes -Value $WmiProcess.PrivateBytes
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Description -Value $PoshProcess.Description
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name ParentPid -Value $WmiProcess.CreatingProcessID
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name SessionId -Value $PoshProcess.SessionId
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Handles -Value $WmiProcess.HandleCount
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Threads -Value $WmiProcess.ThreadCount
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Path -Value $PoshProcess.Path
+
+    $OutputObjects += $OutputObject
+    # Do not null object it is used further down to extract correct ordering of object properties
+    #$OutputObject = $Null
 }
-# Change the display order based on user selected property being sorted on
-$OutputOrdering = @($OrderBy,"Pid", "Name", "CpuPercent", "PrivateBytes", "Description", "ParentPid", "SessionId", "Handles", "Threads") | Select-Object -Unique
+
+
+# Get properties of object to be displayed in output, note OutputObject must by used as OutputObjects gives strange return
+[System.Collections.ArrayList]$OutPutOrdering = $OutputObject.psobject.Properties.Name
+# Add proprty being sorted on to list of properties (will generate duplicate entry)
+$OutPutOrdering.Insert(0,$OrderBy) 
+# Remove the duplicate from the list of properties (will preserve the first one in the list)
+$OutPutOrdering = $OutPutOrdering | Select-Object -Unique
+
 if ($Format -eq 'text')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering `
+        | Select-Object -First $Top -Property $OutputOrdering -ExcludeProperty Path `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
@@ -81,7 +90,7 @@ elseif ($Format -eq 'csv')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top  `
+        | Select-Object -First $Top -Property $OutputOrdering `
         | convertto-csv -NoTypeInformation `
         | Out-String -Width 4096 `
         | Write-Host
@@ -90,7 +99,7 @@ elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top `
+        | Select-Object -First $Top -Property $OutputOrdering `
         | convertto-json `
         | Out-String -Width 4096 `
         | Write-Host
@@ -99,7 +108,7 @@ elseif ($Format -eq 'list')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering `
+        | Select-Object -First $Top -Property $OutputOrdering -ExcludeProperty Path `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -81,7 +81,7 @@ if ($Format -eq 'text')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering -ExcludeProperty Path `
+        | Select-Object -First $Top -Property $OutPutOrdering -ExcludeProperty Path `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
@@ -90,7 +90,7 @@ elseif ($Format -eq 'csv')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering `
+        | Select-Object -First $Top -Property $OutPutOrdering `
         | convertto-csv -NoTypeInformation `
         | Out-String -Width 4096 `
         | Write-Host
@@ -99,7 +99,7 @@ elseif ($Format -eq 'json')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering `
+        | Select-Object -First $Top -Property $OutPutOrdering `
         | convertto-json `
         | Out-String -Width 4096 `
         | Write-Host
@@ -108,7 +108,7 @@ elseif ($Format -eq 'list')
 {
     $OutputObjects `
         | Sort-Object -Property $OrderBy -Descending:$Desc `
-        | Select-Object -First $Top -Property $OutputOrdering -ExcludeProperty Path `
+        | Select-Object -First $Top -Property $OutPutOrdering -ExcludeProperty Path `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -71,9 +71,10 @@ foreach ($PoshProcess in $PoshProcesses)
 
 
 # Get properties of object to be displayed in output, note OutputObject must by used as OutputObjects gives strange return
+# Get-Member can not be used here as it does not perserve the property order in the object
 [System.Collections.ArrayList]$OutPutOrdering = $OutputObject.psobject.Properties.Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
-$OutPutOrdering.Insert(0,$OrderBy) 
+$OutPutOrdering.Insert(0,$OrderBy)
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique
 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -72,7 +72,7 @@ foreach ($PoshProcess in $PoshProcesses)
 
 # Get properties of object to be displayed in output, note OutputObject must by used as OutputObjects gives strange return
 [System.Collections.ArrayList]$OutPutOrdering = $OutputObject.psobject.Properties.Name
-# Add proprty being sorted on to list of properties (will generate duplicate entry)
+# Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,$OrderBy) 
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -22,7 +22,7 @@ $Services = Get-Service
 # Get properties of object to be displayed in output (Get-Memeber does not honor order of properties in object)
 [System.Collections.ArrayList]$OutPutOrdering = $Services | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
-$OutPutOrdering.Insert(0,"Name") 
+$OutPutOrdering.Insert(0,"Name")
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique
 
@@ -39,7 +39,7 @@ elseif ($Format -eq 'csv')
 {
     $Services `
         | Sort-Object -Property Name `
-        | Select-Object -Property $OutputOrdering `
+        | Select-Object -Property $OutPutOrdering `
         | ConvertTo-Csv -NoTypeInformation `
         | Out-String -Width 4096 `
         | Write-Host
@@ -48,7 +48,7 @@ elseif ($Format -eq 'json')
 {
     $Services `
         | Sort-Object -Property Name `
-        | Select-Object -Property $OutputOrdering `
+        | Select-Object -Property $OutPutOrdering `
         | ConvertTo-Json `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -17,36 +17,47 @@ Param(
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "stop"
 
+$Services = Get-Service
+
+# Get properties of object to be displayed in output
+[System.Collections.ArrayList]$OutPutOrdering = $Services | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
+# Add proprty being sorted on to list of properties (will generate duplicate entry)
+$OutPutOrdering.Insert(0,"Name") 
+# Remove the duplicate from the list of properties (will preserve the first one in the list)
+$OutPutOrdering = $OutPutOrdering | Select-Object -Unique
+
 if ($Format -eq 'text')
 {
-    Get-Service `
+    $Services `
         | Sort-Object -Property Name `
-        | Select-Object Name, Status, DisplayName  `
+        | Select-Object -Property Name, Status, DisplayName `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
 }
 elseif ($Format -eq 'csv')
 {
-    Get-Service `
+    $Services `
         | Sort-Object -Property Name `
+        | Select-Object -Property $OutputOrdering `
         | ConvertTo-Csv -NoTypeInformation `
         | Out-String -Width 4096 `
         | Write-Host
 }
 elseif ($Format -eq 'json')
 {
-    Get-Service `
+    $Services `
         | Sort-Object -Property Name `
+        | Select-Object -Property $OutputOrdering `
         | ConvertTo-Json `
         | Out-String -Width 4096 `
         | Write-Host
 }
 elseif ($Format -eq 'list')
 {
-    Get-Service `
+    $Services `
         | Sort-Object -Property Name `
-        | Select-Object Name, Status, DisplayName  `
+        | Select-Object -Property Name, Status, DisplayName `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -21,7 +21,7 @@ $Services = Get-Service
 
 # Get properties of object to be displayed in output
 [System.Collections.ArrayList]$OutPutOrdering = $Services | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
-# Add proprty being sorted on to list of properties (will generate duplicate entry)
+# Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,"Name") 
 # Remove the duplicate from the list of properties (will preserve the first one in the list)
 $OutPutOrdering = $OutPutOrdering | Select-Object -Unique

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -19,7 +19,7 @@ $ErrorActionPreference = "stop"
 
 $Services = Get-Service
 
-# Get properties of object to be displayed in output
+# Get properties of object to be displayed in output (Get-Memeber does not honor order of properties in object)
 [System.Collections.ArrayList]$OutPutOrdering = $Services | Get-Member -MemberType AliasProperty,Property | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,"Name") 

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Services.ps1
@@ -21,7 +21,7 @@ if ($Format -eq 'text')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | Select-Object DisplayName, Status, Name  `
+        | Select-Object Name, Status, DisplayName  `
         | Format-Table -AutoSize `
         | Out-String -Width 4096 `
         | Write-Host
@@ -46,7 +46,7 @@ elseif ($Format -eq 'list')
 {
     Get-Service `
         | Sort-Object -Property Name `
-        | Select-Object DisplayName, Status, Name  `
+        | Select-Object Name, Status, DisplayName  `
         | Format-List `
         | Out-String -Width 4096 `
         | Write-Host


### PR DESCRIPTION
Updated output ordering logic for Get-Eventlogs, Get-Process and Get-Services. Ordering will now be done based on the property being used for sorting.

It will do this for all the supported types: 
text,csv,json and list

Ref: 
https://github.com/squaredup/Community.DataOnDemand.MP/issues/25

Tested only in powershell and not as a finished MP. Also not tested with PS 2.0 