### PR TITLE
Get Processes now correctly calculates CPU % over multiple cores

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -37,10 +37,11 @@ $PoshProcesses = @(Get-Process)
 # WMI doesn't report process description and other fields
 Function Get-WMIProcPerfSample
 {
+    # Query Raw per process performance counters, excluding PID 0 as that will have Idle and _Total artificial processes listed.
     Get-WmiObject -Class Win32_PerfRawData_PerfProc_Process -Filter 'IDProcess != 0' -Property IDProcess,CreatingProcessID,PercentProcessorTime,TimeStamp_Sys100NS,ElapsedTime
 }
 
-# Sample activity over 1 second
+# Sample activity over 1 second (same as Task manager)
 $WMIPerfData = @{}
 $sampleSet1 = @{}
 Get-WMIProcPerfSample | ForEach-Object {$sampleSet1[$_.IDProcess] = $_}

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Processes.ps1
@@ -30,24 +30,46 @@ $ErrorActionPreference = "stop"
 # SCOM passes in the string "false" which won't bind to a [bool]
 $Desc = [System.Convert]::ToBoolean($Descending);
 
-# The cmdlet doesn't report % cpu usage, parent process id, ...
+# The cmdlet doesn't report % cpu usage, parent process id
 $PoshProcesses = @(Get-Process)
 
-# WMI doesn't report process description, ...
-$WmiProcesses = @(get-wmiobject Win32_PerfFormattedData_PerfProc_Process)
+# Get Proc usage statstics
+# WMI doesn't report process description and other fields
+Function Get-WMIProcPerfSample
+{
+    Get-WmiObject -Class Win32_PerfRawData_PerfProc_Process -Filter 'IDProcess != 0' -Property IDProcess,CreatingProcessID,PercentProcessorTime,TimeStamp_Sys100NS,ElapsedTime
+}
 
-# Iterate through PoshProcesses doing lookups against WmiProcesses for extra info
-# Normalize hash key datatype to string
-# Filter out idle process 0. WMI also reports a bogus _Total process with ID 0.
-$WmiProcessLookup = @{};
-$WmiProcesses | Where-Object { $_.IDProcess -ne 0 } `
-              | Where-Object { -not $WmiProcessLookup.ContainsKey("$($_.IDProcess)")} `
-              | ForEach-Object { $WmiProcessLookup.Add("$($_.IDProcess)",$_) };
+# Sample activity over 1 second
+$WMIPerfData = @{}
+$sampleSet1 = @{}
+Get-WMIProcPerfSample | ForEach-Object {$sampleSet1[$_.IDProcess] = $_}
+Start-Sleep -Seconds 1
+
+# Take a second sample, and populate the WMIPerf hashtable with the results
+Foreach ($sample in Get-WMIProcPerfSample) {
+    # If the process only appears in the second sample (started after the delay) you can use the lifetime values directly
+    $procTime = $sample.PercentProcessorTime
+    $timeWindow = ($sample.TimeStamp_Sys100NS - $sample.ElapsedTime)
+
+    # If the process existed in the first sample, use deltas over the sample period
+    If ($sampleSet1.ContainsKey($sample.IDProcess))
+    {
+        $procTime = $sample.PercentProcessorTime - $sampleSet1[$sample.IDProcess].PercentProcessorTime
+        $timeWindow = $sample.TimeStamp_Sys100NS - $sampleSet1[$sample.IDProcess].TimeStamp_Sys100NS
+    }
+    # Percent Processor Time will be accross all LogicalProcessors and can exceed 100
+    $WMIPerfData["$($sample.IDProcess)"] = New-Object -TypeName PSObject -Property @{
+        "PID"=$sample.IDProcess;
+        "CreatingProcessID"=$sample.CreatingProcessID;
+        "PercentProcessorTime"=($procTime / $timeWindow) * 100 / [System.Environment]::ProcessorCount
+    }
+}
 
 $OutputObjects= @();
 foreach ($PoshProcess in $PoshProcesses)
 {
-    $WmiProcess = $WmiProcessLookup["$($PoshProcess.Id)"];
+    $WmiProcess = $WMIPerfData["$($PoshProcess.Id)"];
     if (-not $WmiProcess -or $PoshProcess.Id -eq 0) {
         continue;
     }
@@ -56,13 +78,13 @@ foreach ($PoshProcess in $PoshProcesses)
     $OutputObject = New-Object -TypeName PSObject
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Pid -Value $PoshProcess.Id
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Name -Value $PoshProcess.Name
-    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name CpuPercent -Value $WmiProcess.PercentProcessorTime
-    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name PrivateBytes -Value $WmiProcess.PrivateBytes
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name CpuPercent -Value ([Math]::Round($WmiProcess.PercentProcessorTime, 2))
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name PrivateBytes -Value $PoshProcess.PrivateMemorySize64
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Description -Value $PoshProcess.Description
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name ParentPid -Value $WmiProcess.CreatingProcessID
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name SessionId -Value $PoshProcess.SessionId
-    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Handles -Value $WmiProcess.HandleCount
-    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Threads -Value $WmiProcess.ThreadCount
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Handles -Value $PoshProcess.Handles
+    Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Threads -Value $PoshProcess.Threads.Count
     Add-Member -InputObject $OutputObject -MemberType NoteProperty -Name Path -Value $PoshProcess.Path
 
     $OutputObjects += $OutputObject
@@ -75,8 +97,8 @@ foreach ($PoshProcess in $PoshProcesses)
 [System.Collections.ArrayList]$OutPutOrdering = $OutputObjects[0].psobject.Properties | Select-Object -ExpandProperty Name
 # Add proprty being sorted, so it will be the first property to be displayed in output(will generate duplicate entry)
 $OutPutOrdering.Insert(0,$OrderBy)
-# Remove the duplicate from the list of properties (will preserve the first one in the list)
-$OutPutOrdering = $OutPutOrdering | Select-Object -Unique
+# Remove the duplicate from the list of properties (will preserve the first one in the list), and ensure they are strings to handle a PS v2 object wrapping issue with Select-Object
+$OutPutOrdering = $OutPutOrdering | Select-Object -Unique | Foreach-Object {$_.ToString()}
 
 if ($Format -eq 'text')
 {


### PR DESCRIPTION
This was an interesting learning experience..

Turns out the previous method we were using of calculating CPU % did not correctly handle multi core systems.  Looking at alternate solutions highlighted problems with pretty much all of them

- Win32_PerfFormattedData_PerfProc_Process (the original) caps the usage value at 100 despite the fact this will be exceeded if the process is using more than a single core, so you can neither use the value directly nor infer it by dividing by the core count.
- Win32_PerfFormattedData_PerfProc_Thread gives you the per thread values, but cannot display values less than 1%.  This means if a proc has 25 threads, some of which are using 0.8% the proc's usage will be reported as 0% even though it could be using 20% CPU (this isn't an academic example, it was happening on my machine during testing!).
- Get-Counter doesn't handle multiple cores properly, has rounding error issues *AND* will occasionally throw an exception regarding one of the values being incorrect.

So in the end, this PR just samples the raw CPU time values across a 1 second sample (same as task manager) and calculates it correctly.

This resolves Issue #28 