### PR TITLE
Add Get-WindowsUpdateHistory to Data on Demand MP

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Community.DataOnDemand.mpproj
+++ b/ManagementPacks/Community.DataOnDemand/Community.DataOnDemand.mpproj
@@ -71,6 +71,9 @@
     <Compile Include="Modules\GetServicesWA.mpx">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Modules\GetWindowsUpdateHistoryProbe.mpx">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Modules\ResolveAddressProbe.mpx">
       <SubType>Code</SubType>
     </Compile>
@@ -89,6 +92,9 @@
     <Compile Include="Tasks\GetServices.mpx">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Tasks\GetWindowsUpdateHistory.mpx">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Tasks\ResolveAddress.mpx">
       <SubType>Code</SubType>
     </Compile>
@@ -104,6 +110,7 @@
     <EmbeddedResource Include="Scripts\Get-Netstat.ps1" />
     <EmbeddedResource Include="Scripts\Get-Processes.ps1" />
     <EmbeddedResource Include="Scripts\Get-Services.ps1" />
+    <EmbeddedResource Include="Scripts\Get-WindowsUpdateHistory.ps1" />
     <EmbeddedResource Include="Scripts\Resolve-Address.ps1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VSAC\Microsoft.SystemCenter.OperationsManager.targets" />

--- a/ManagementPacks/Community.DataOnDemand/Modules/GetWindowsUpdateHistoryProbe.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Modules/GetWindowsUpdateHistoryProbe.mpx
@@ -59,8 +59,8 @@
     <LanguagePack ID="ENU" IsDefault="true">
       <DisplayStrings>
         <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory">
-          <Name>Data On Demand Windows windows update history probe action</Name>
-          <Description>Returns a list of windows update events on the target computer.</Description>
+          <Name>Data On Demand Windows update history probe action</Name>
+          <Description>Returns a list of Windows update events on the target computer.</Description>
         </DisplayString>
         <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="ExcludedKB">
           <Name>Excluded KBs</Name>

--- a/ManagementPacks/Community.DataOnDemand/Modules/GetWindowsUpdateHistoryProbe.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Modules/GetWindowsUpdateHistoryProbe.mpx
@@ -1,0 +1,89 @@
+<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <TypeDefinitions>
+    <ModuleTypes>
+      <ProbeActionModuleType ID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" Accessibility="Public" Batching="false">
+        <Configuration>
+          <xsd:element name="ExcludedKB" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="Format" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="TimeoutSeconds" type="xsd:int" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="LastHours" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+          <xsd:element name="ShowTop" type="xsd:string" xmlns:xsd="http://www.w3.org/2001/XMLSchema" />
+        </Configuration>
+        <OverrideableParameters>
+          <OverrideableParameter ID="ExcludedKB" Selector="$Config/ExcludedKB$" ParameterType="string" />
+          <OverrideableParameter ID="Format" Selector="$Config/Format$" ParameterType="string" />
+          <OverrideableParameter ID="ShowTop" Selector="$Config/ShowTop$" ParameterType="string" />
+          <OverrideableParameter ID="LastHours" Selector="$Config/LastHours$" ParameterType="string" />
+          <OverrideableParameter ID="TimeoutSeconds" Selector="$Config/TimeoutSeconds$" ParameterType="int" />
+        </OverrideableParameters>
+        <ModuleImplementation>
+          <Composite>
+            <MemberModules>
+              <ProbeAction ID="Probe" TypeID="Windows!Microsoft.Windows.PowerShellTriggerOnlyProbe">
+                <ScriptName>Get-WindowsUpdateHistory.ps1</ScriptName>
+                <ScriptBody>$IncludeFileContent/Scripts/Get-WindowsUpdateHistory.ps1$</ScriptBody>
+                <Parameters>
+                  <Parameter>
+                    <Name>ExcludedKB</Name>
+                    <Value>$Config/ExcludedKB$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>Format</Name>
+                    <Value>$Config/Format$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>ShowTop</Name>
+                    <Value>$Config/ShowTop$</Value>
+                  </Parameter>
+                  <Parameter>
+                    <Name>LastHours</Name>
+                    <Value>$Config/LastHours$</Value>
+                  </Parameter>
+                </Parameters>
+                <TimeoutSeconds>$Config/TimeoutSeconds$</TimeoutSeconds>
+              </ProbeAction>
+            </MemberModules>
+            <Composition>
+              <Node ID="Probe" />
+            </Composition>
+          </Composite>
+        </ModuleImplementation>
+        <OutputType>Windows!Microsoft.Windows.SerializedObjectData</OutputType>
+        <TriggerOnly>true</TriggerOnly>
+      </ProbeActionModuleType>
+    </ModuleTypes>
+  </TypeDefinitions>
+
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory">
+          <Name>Data On Demand Windows windows update history probe action</Name>
+          <Description>Returns a list of windows update events on the target computer.</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="ExcludedKB">
+          <Name>Excluded KBs</Name>
+          <Description>A comma seperated list of KBs to exclude from the results.</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="ShowTop">
+          <Name>Top</Name>
+          <Description>If specified, only return the specified number of results.</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="LastHours">
+          <Name>Last Hours</Name>
+          <Description>If specified, only return events from the last X hours.</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="Format">
+          <Name>Format</Name>
+          <Description>Output format. Allowed values: csv, json, text, list.</Description>
+        </DisplayString>
+        <DisplayString ElementID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory" SubElementID="TimeoutSeconds">
+          <Name>Timeout (seconds)</Name>
+          <Description>Script timeout in seconds.</Description>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+
+</ManagementPackFragment>

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
@@ -22,10 +22,6 @@ $output = @()
 # put the header in
 $output += 'KB Article,KB Name,Installation Date,Installation Status'
 
-# get the name of the current time zone
-$currentTimeZoneName = (Get-WmiObject Win32_TimeZone).StandardName
-$timeZone = [System.TimeZoneInfo]::FindSystemTimeZoneById($currentTimeZoneName)
-
 # create a new instance of the Update Session COM object
 $Session = New-Object -ComObject Microsoft.Update.Session
 
@@ -76,7 +72,7 @@ foreach ($item in $queryResult)
 
 	# create a new object and populate it with values; note that the InstallOn value is converted to the local Server time
 	$newObject = New-Object -TypeName PSObject -Property @{
-		InstalledOn = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date -Date $item.Date), $timeZone);
+		InstalledOn =$item.Date;
 		KBArticle = $Title;
 		Name = $item.Title;
 		Status = $Result
@@ -113,7 +109,7 @@ foreach ($item in $WindowsUpdates)
 	$output += '"{0}","{1}","{2}","{3}"%EOL%' -f `
 		$item.KBArticle,
 		$item.Name,
-		$item.InstalledOn.ToString("g"),
+		$item.InstalledOn.ToString("u"),
 		$item.Status
 
 	# if the parameter for 'top' n was specified then....

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+Community.DataOnDemand windows update enumeration script
+.DESCRIPTION
+This script enumerates windows updates and outputs formatted text
+.PARAMETER Format
+Permitted values: text, csv, json
+.NOTES
+Copyright
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+Param(
+	[ValidateSet("text","csv","csvEx","json","list")]
+	[string] $Format = "csv",
+	[int]$ShowTop,
+	[string]$ExcludedKB
+)
+
+# define a variable to hold the output
+$output = @()
+
+# put the header in
+$output += 'KB Article,KB Name,Installation Date,Installation Status'
+
+# get the name of the current time zone
+$currentTimeZoneName = (Get-WmiObject Win32_TimeZone).StandardName
+$timeZone = [System.TimeZoneInfo]::FindSystemTimeZoneById($currentTimeZoneName)
+
+# create a new instance of the Update Session COM object
+$Session = New-Object -ComObject Microsoft.Update.Session
+
+# create a searcher object
+$Searcher = $Session.CreateUpdateSearcher()
+
+# get the count of elements in the history
+$HistoryCount = $Searcher.GetTotalHistoryCount()
+
+# query for the updates
+$queryResult = $Searcher.QueryHistory(0,$HistoryCount)
+
+# create a collection to hold the items we are about to create
+[System.Collections.ArrayList]$WindowsUpdates = New-Object -Type System.Collections.ArrayList
+
+# loop through the query results
+foreach ($item in $queryResult)
+{
+	# make sure the title variable is empty
+	$Title = $null
+
+	# if the title contains a KB article number then...
+	if($item.Title -match "\(KB\d{6,7}\)"){
+
+		# split the title apart and put the actual title, minus the KB ref, into the title variable
+		$Title = ($item.Title -split '.*\((KB\d{6,7})\)')[1]
+	}
+	else
+	{
+	# the title is just pulled from the query
+	$Title = $item.Title
+	}
+
+	# make sure the result is empty
+	$Result = $null
+
+	# load the result based on the value of the result code
+	Switch ($item.ResultCode)
+	{
+		0 { $Resul = 'NotStarted'}
+		1 { $Result = 'InProgress' }
+		2 { $Result = 'Succeeded' }
+		3 { $Result = 'SucceededWithErrors' }
+		4 { $Result = 'Failed' }
+		5 { $Result = 'Aborted' }
+		default { $Result = $item.ResultCode }
+	}
+
+	# create a new object and populate it with values; note that the InstallOn value is converted to the local Server time
+	$newObject = New-Object -TypeName PSObject -Property @{
+		InstalledOn = [System.TimeZoneInfo]::ConvertTimeFromUtc((Get-Date -Date $item.Date), $timeZone);
+		KBArticle = $Title;
+		Name = $item.Title;
+		Status = $Result
+	}
+
+	# add to the collection
+	$WindowsUpdates.Add($newObject) | Out-Null
+}
+
+# sort by installedOn value
+$WindowsUpdates = ($WindowsUpdates | Sort-Object InstalledOn -Descending:$true)
+
+# next remove any that are being filtered out
+# if any exclusions are specified
+if ($ExcludedKB -ne "")
+{
+	# split the string out
+	$arrExclusionList = $ExcludedKB.Split(",")
+
+	# and then do the filter for each element
+	foreach ($item in $arrExclusionList)
+	{
+		$WindowsUpdates = ($WindowsUpdates | Where-Object { $_.KBArticle -inotlike ('*KB' + $item + "*") })
+	}
+}
+
+# create a counter variable
+[int]$loopCounter = 1
+
+# loop through the elements to build the output string
+foreach ($item in $WindowsUpdates)
+{
+	# create a new line in the output file
+	$output += '"{0}","{1}","{2}","{3}"%EOL%' -f `
+		$item.KBArticle,
+		$item.Name,
+		$item.InstalledOn.ToString("g"),
+		$item.Status
+
+	# if the parameter for 'top' n was specified then....
+	if ($ShowTop -gt -1)
+	{
+		if ($loopCounter -ge $ShowTop) { break } else { $loopCounter++ }
+	}
+}
+
+# output to the required format
+if ($Format -eq 'text')
+{
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	| Format-Table -AutoSize `
+	| Out-String -Width 4096 `
+	| Write-Host
+}
+elseif ($Format -eq 'csv')
+{
+	$output -replace '%EOL%','' `
+	| Out-String -Width 4096 `
+	| Write-Host
+}
+elseif ($Format -eq 'csvEx')
+{
+	$output `
+	| Out-String -Width 4096 `
+	| Write-Host
+}
+elseif ($Format -eq 'json')
+{
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	| ConvertTo-Json `
+	| Out-String -Width 4096 `
+	| Write-Host
+}
+elseif ($Format -eq 'list')
+{
+	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	| Format-List `
+	| Out-String -Width 4096 `
+	| Write-Host
+}
+
+# Done. (do not remove blank line following this comment as it can cause problems when script is sent to SCOM agent!)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
@@ -65,7 +65,7 @@ foreach ($item in $queryResult)
 	# load the result based on the value of the result code
 	Switch ($item.ResultCode)
 	{
-		0 { $Resul = 'NotStarted'}
+		0 { $Result = 'NotStarted'}
 		1 { $Result = 'InProgress' }
 		2 { $Result = 'Succeeded' }
 		3 { $Result = 'SucceededWithErrors' }

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdate.ps1
@@ -29,7 +29,7 @@ $Searcher = $Session.CreateUpdateSearcher()
 $queryResult = $Searcher.QueryHistory(0,$Searcher.GetTotalHistoryCount())
 
 # create a collection to hold the items we are about to create
-$WindowsUpdates = @()
+[System.Collections.ArrayList]$WindowsUpdates = New-Object -Type System.Collections.ArrayList
 
 # Populate Exclusion List (adding if specified)
 $ExclusionList = @()
@@ -97,7 +97,7 @@ for ($i = 0; $i -lt $outputCount; $i++) {
     $item = $WindowsUpdates[$i]
 
     # create a new line in the output file
-	$output += '"{0}","{1}","{2}","{3}"%EOL%' -f `
+	$output += '"{0}","{1}","{2}","{3}"' -f `
         $item.KBArticle,
         $item.Name,
         $item.InstalledOn.ToString("u"),
@@ -107,33 +107,34 @@ for ($i = 0; $i -lt $outputCount; $i++) {
 # output to the required format
 if ($Format -eq 'text')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	ConvertFrom-Csv $output `
 	| Format-Table -AutoSize `
 	| Out-String -Width 4096 `
 	| Write-Host
 }
 elseif ($Format -eq 'csv')
 {
-	$output -replace '%EOL%','' `
+	$output`
 	| Out-String -Width 4096 `
 	| Write-Host
 }
 elseif ($Format -eq 'csvEx')
 {
-	$output `
+    $output `
+    | ForEach-Object {"$_%EOL%"} `
 	| Out-String -Width 4096 `
 	| Write-Host
 }
 elseif ($Format -eq 'json')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	ConvertFrom-Csv $output `
 	| ConvertTo-Json `
 	| Out-String -Width 4096 `
 	| Write-Host
 }
 elseif ($Format -eq 'list')
 {
-	ConvertFrom-Csv ($output -replace '%EOL%','') `
+	ConvertFrom-Csv $output `
 	| Format-List `
 	| Out-String -Width 4096 `
 	| Write-Host

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdateHistory.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdateHistory.ps1
@@ -46,6 +46,7 @@ if ($ExcludedKB -ne "")
     $ExclusionList = $ExcludedKB.Split(",") | ForEach-Object { $_ -replace '^(KB)?(\d{6,7})','KB$2'}
 }
 
+# generate the date events must be newer than
 $since = [datetime]::MinValue
 if ($LastHours) {
     $since = [datetime]::UtcNow.AddHours(-1 * $LastHours)

--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdateHistory.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-WindowsUpdateHistory.ps1
@@ -18,7 +18,7 @@ Copyright 2018 Squared Up Limited, All Rights Reserved.
 Param(
 	[ValidateSet("text","csv","csvEx","json","list")]
 	[string] $Format = "csv",
-	[int]$ShowTop = [int]::MaxValue,
+	[int]$ShowTop,
     [string]$ExcludedKB,
     [int]$LastHours
 )
@@ -69,7 +69,6 @@ foreach ($item in $queryResult)
 	if($item.Title -match "\(?KB\d{6,7}\)?"){
 
         # put the actual title, minus the KB ref, into the title variable
-        #$split = ($item.Title -split '\s?\((KB\d{6,7})\)')
         $KBArticle = $Matches[0].Trim(' ','(',')')
         $Title = $item.title -replace "\s?\(?$KBArticle\)?",''
 	}
@@ -110,6 +109,10 @@ foreach ($item in $queryResult)
 $WindowsUpdates = @($WindowsUpdates | Sort-Object InstalledOn -Descending:$true)
 
 # loop through the elements to build the output string, limited by ShowTop
+# Due to the way null values are bound by SCOM -> PS, a default value in the param will always be overridden
+if (-not $ShowTop) {
+	$ShowTop = [int]::MaxValue
+}
 $outputCount = [math]::Min($ShowTop, $WindowsUpdates.Count)
 
 for ($i = 0; $i -lt $outputCount; $i++) {

--- a/ManagementPacks/Community.DataOnDemand/Tasks/GetWindowsUpdateHistory.mpx
+++ b/ManagementPacks/Community.DataOnDemand/Tasks/GetWindowsUpdateHistory.mpx
@@ -1,0 +1,28 @@
+<ManagementPackFragment SchemaVersion="2.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Monitoring>
+    <Tasks>
+      <Task ID="Community.DataOnDemand.AgentTask.GetWindowsUpdateHistory" Accessibility="Public" Enabled="true" Remotable="false" Target="Windows!Microsoft.Windows.Computer">
+        <Category>Operations</Category>
+        <ProbeAction ID="Probe" TypeID="Community.DataOnDemand.Probe.GetWindowsUpdateHistory">
+          <ExcludedKB></ExcludedKB>
+          <Format>csv</Format>
+          <TimeoutSeconds>60</TimeoutSeconds>
+          <LastHours></LastHours>
+          <ShowTop></ShowTop>
+        </ProbeAction>
+      </Task>
+    </Tasks>
+  </Monitoring>
+  <LanguagePacks>
+    <LanguagePack ID="ENU" IsDefault="true">
+      <DisplayStrings>
+        <DisplayString ElementID="Community.DataOnDemand.AgentTask.GetWindowsUpdateHistory">
+          <Name>List Update History (Data On Demand)</Name>
+          <Description>Lists Windows Update activity on the target computer.
+            Note: JSON format is only supported if PowerShell v3 or later is installed on the target server.
+          </Description>
+        </DisplayString>
+      </DisplayStrings>
+    </LanguagePack>
+  </LanguagePacks>
+</ManagementPackFragment>


### PR DESCRIPTION
Added task submitted by @wiredworm with some modifications.

This task will show the Windows Update history for the target machine, with optional parameters to exclude certain KBs, only show events from the last X hours, and only show a certain number of entries.

This PR resolved #30 