### PR TITLE
SU-6144: IIS workers script always returns app/pool pair

### DIFF
--- a/ManagementPacks/Community.DataOnDemand.IIS/Scripts/Get-IISWorkerData.ps1
+++ b/ManagementPacks/Community.DataOnDemand.IIS/Scripts/Get-IISWorkerData.ps1
@@ -171,16 +171,6 @@ if ($wpData) {
     }
 }
 
-$appsByPool = @{}
-if ($appData) {
-	foreach ($app in $appData) {
-		if (-not $appsByPool.ContainsKey($app.AppPool)) {
-			$appsByPool[$app.AppPool] = @{}
-		}
-		$appsByPool[$app.AppPool][$app.App] = $true
-	}
-}
-
 $portsByProcId = @{}
 if ($netshData) {
     foreach ($entry in $netshData) {


### PR DESCRIPTION
This PR modifies the Get Worker Process task in the IIS Data On Demand MP to always return entries for application -> pool pairs, even if the pool is currently asleep (no worker processes running, typically due to traffic inactivity).

App/Pool pairs without workers now simply return a null value for Pid and Port.  Existing consumers of this task within Squared Up are not impacted by this change. Crucially, this will allow and updated IIS VADA plugin to correctly associate non-website apps to their application pool at discovery time, and give us an additional mechanism to filter traffic (many apps may share port 80, but apps whose worker is asleep are not receiving that traffic).