### PR TITLE
SQ-5125 Updated NetSh Regex to work with Windows 2022

### DIFF
--- a/ManagementPacks/Community.DataOnDemand.IIS/Scripts/Get-IISWorkerData.ps1
+++ b/ManagementPacks/Community.DataOnDemand.IIS/Scripts/Get-IISWorkerData.ps1
@@ -48,7 +48,8 @@ $appcmd = "$Env:WinDir\system32\inetsrv\appCmd.exe"
 
 # Useful REs - must avoid using localised strings in here
 $netshRequestqBreakRe = New-Object Regex '^\S'
-$netshPidRe = New-Object Regex '^\s*(?<PID>\d+)\s*$'
+# https://regex101.com/r/qZ9PBy/1
+$netshPidRe = New-Object Regex '^\s*(?:Process IDs:\n\s+(?<PID>\d+)\s*$|Processes:\n\s+ID: (?<PID>\d+),)'
 $netshUrlRe = New-Object Regex ('^\s+https?://[^:]+:(?<PORT>\d+)',[System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
 
 function ProcessBatch {


### PR DESCRIPTION
Link to JIRA: [SQ-5125](https://squaredup-eng.atlassian.net/browse/SQ-5125/)

## Description of the change

- Updated regex for use with `netsh.exe` so it's compatible with Windows Server 2016 and Windows Server 2022

## Test impact

Test app pools are discovered by VADA and linked with discovered network connections