### PR TITLE
ADO-647 Replace old image

### DIFF
--- a/azure-pipelines-unix.yml
+++ b/azure-pipelines-unix.yml
@@ -3,8 +3,8 @@ stages:
   - stage: buildStage
     displayName: Build Stage
     pool:
-      vmImage: "vs2017-win2016"
-      name: Azure Pipelines
+      vmImage: $(MANAGEMENT_VM_IMAGE)
+      name: $(MANAGEMENT_AGENT_NAME)
       demands:
         - msbuild
         - visualstudio

--- a/azure-pipelines-unix.yml
+++ b/azure-pipelines-unix.yml
@@ -56,7 +56,7 @@ stages:
                 displayName: "Visual Studio Build"
                 inputs:
                     solution: "$(buildsolutionFile)"
-                    vsVersion: "15.0"
+                    vsVersion: "17.0"
                     msbuildArgs: '/verbosity:minimal /p:Version=$(DEMAND_MAJOR_VERSION).$(DEMAND_MINOR_VERSION).$(DEMAND_REVISION).$(BUILD_NUMBER) /p:AssemblyOriginatorKeyFile=$(STRONGNAME_KEY.secureFilePath)'
                     platform: "$(buildPlatform)"
                     configuration: "$(buildConfiguration)"

--- a/azure-pipelines-unix.yml
+++ b/azure-pipelines-unix.yml
@@ -5,11 +5,6 @@ stages:
     pool:
       vmImage: $(MANAGEMENT_VM_IMAGE)
       name: $(MANAGEMENT_AGENT_NAME)
-      demands:
-        - msbuild
-        - visualstudio
-        - Cmd
-        - vstest
     jobs:
       - 
           job: "buildJob"

--- a/azure-pipelines-unix.yml
+++ b/azure-pipelines-unix.yml
@@ -22,8 +22,8 @@ stages:
                 inputs:
                   targetType: inline
                   script: | 
-                    $s3URI = "https://s3.amazonaws.com/releases.squaredup/squaredupltd/tools%26scripts/vsae-msi/VisualStudioAuthoringConsole_x86.msi"
-                    $file = "$(System.DefaultWorkingDirectory)\VisualStudioAuthoringConsole_x86.msi"
+                    $s3URI = "https://s3.amazonaws.com/releases.squaredup/squaredupltd/tools%26scripts/vsae-msi/VisualStudio2022AuthoringConsole_x64_v1.4.1.1.msi"
+                    $file = "$(System.DefaultWorkingDirectory)\VisualStudio2022AuthoringConsole_x64_v1.4.1.1.msi"
                     Write-Host "Downloading Build from $s3URI to $file"
                     (New-Object System.Net.WebClient).DownloadFile($s3URI, $file)
                     Get-ChildItem $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,8 @@ stages:
     - stage: buildStage
       displayName: 'Build Stage'
       pool:
-          vmImage: "vs2017-win2016"
-          name: Azure Pipelines
+          vmImage: $(MANAGEMENT_VM_IMAGE)
+          name: $(MANAGEMENT_AGENT_NAME)
           demands:
               - msbuild
               - visualstudio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
                     displayName: "Visual Studio Build"
                     inputs:
                         solution: "$(buildsolutionFile)"
-                        vsVersion: "15.0"
+                        vsVersion: "17.0"
                         msbuildArgs: '/verbosity:minimal /p:Version=$(DEMAND_MAJOR_VERSION).$(DEMAND_MINOR_VERSION).$(DEMAND_REVISION).$(BUILD_NUMBER) /p:AssemblyOriginatorKeyFile=$(STRONGNAME_KEY.secureFilePath)'
                         platform: "$(buildPlatform)"
                         configuration: "$(buildConfiguration)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,11 +6,6 @@ stages:
       pool:
           vmImage: $(MANAGEMENT_VM_IMAGE)
           name: $(MANAGEMENT_AGENT_NAME)
-          demands:
-              - msbuild
-              - visualstudio
-              - Cmd
-              - vstest
       jobs:
           - 
               job: "buildJob"
@@ -28,8 +23,8 @@ stages:
                     inputs:
                       targetType: inline
                       script: | 
-                        $s3URI = "https://s3.amazonaws.com/releases.squaredup/squaredupltd/tools%26scripts/vsae-msi/VisualStudioAuthoringConsole_x86.msi"
-                        $file = "$(System.DefaultWorkingDirectory)\VisualStudioAuthoringConsole_x86.msi"
+                        $s3URI = "https://s3.amazonaws.com/releases.squaredup/squaredupltd/tools%26scripts/vsae-msi/VisualStudio2022AuthoringConsole_x64_v1.4.1.1.msi"
+                        $file = "$(System.DefaultWorkingDirectory)\VisualStudio2022AuthoringConsole_x64_v1.4.1.1.msi"
                         Write-Host "Downloading Build from $s3URI to $file"
                         (New-Object System.Net.WebClient).DownloadFile($s3URI, $file)
                         Get-ChildItem $(System.DefaultWorkingDirectory)


### PR DESCRIPTION
Switched the Build Agent to Variables and have upgraded to VS 22 running on windows 22 as 17 is deprecated on ADO