### PR TITLE
ADO-648 switch from 7z to zip

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
                     inputs:
                       rootFolderOrFile: '.\output\'
                       includeRootFolder: false
-                      archiveType: '7z'
+                      archiveType: 'zip'
                       archiveFile: '$(Build.ArtifactStagingDirectory)/Community.DataOnDemand-$(DEMAND_MAJOR_VERSION).$(DEMAND_MINOR_VERSION).$(DEMAND_REVISION)-$(BUILD_NUMBER).zip'
                       replaceExistingArchive: true
                       verbose: true


### PR DESCRIPTION
Previously Archive task utilised 7z but recently it would not open the zip files. So i changed it to zip in order to open the folder.