### PR TITLE
SQ-5443 IPConfig /DisplayDNS uses regex to find fields

### DIFF
--- a/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
+++ b/ManagementPacks/Community.DataOnDemand/Scripts/Get-Netstat.ps1
@@ -38,9 +38,21 @@ $ErrorActionPreference = "stop"
 
 # Cache for DNS lookup
 $dnsCache = @{}
-IPConfig /DisplayDNS | Select-String -Pattern "Record Name" -Context 0,5 | ForEach-Object {
-    if (($_.Context.PostContext[3] -Split ":")[1].Trim() -eq 'Answer') {
-        $dnsCache[($_.Context.PostContext[4] -Split ":")[1].Trim()] = ($_.Line -Split ":")[1].Trim()
+
+$dnsOutput = ipconfig /DisplayDNS | Out-String
+
+# Split by double newlines which separates each DNS record
+$dnsRecords = $dnsOutput -split "(`r`n){2,}" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+foreach ($dnsRecord in $dnsRecords) {
+    if ($dnsRecord -match "Section[\.?\s]*: Answer") {
+        # Capture the Record Name and DNS Record using lookbehind assertions
+        $recordNameMatch = [regex]::Match($dnsRecord, "(?<=\s*Record Name[\.?\s]*: ).+").Value.Trim()
+        $dnsRecordMatch = [regex]::Match($dnsRecord, "(?<=.+ Record[\.?\s]*: ).+").Value.Trim()
+        
+        if(-not [string]::IsNullOrWhiteSpace($recordNameMatch) -and -not [string]::IsNullOrWhiteSpace($dnsRecordMatch)) {
+                $dnsCache[$recordNameMatch] = $dnsRecordMatch
+        }
     }
 }
 


### PR DESCRIPTION
Link to JIRA: [SQ-5443](https://squaredup-eng.atlassian.net/browse/SQ-5443/)

## Description of the change

Updated `Get-Netstat` to use regex to parse the output of `IPConfig /DisplayDNS` allowing it to work with more scenarios and more Windows version (namely 2025)

## Test impact
The script should output exactly the same as before and now work on Windows Server 2025 and Windows 11 whilst retaining compatibility with previous Windows versions.
Test that VADA discovery (which I believe uses this) functions as normal
